### PR TITLE
Close SQLite DB on shutdown and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # MeshPlotter
+
+MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js.
+
+## Quick start
+
+1. Copy `example.config.yml` to `config.yml` and adjust the broker settings.
+2. Install dependencies: `pip install -r requirements.txt`
+3. Start the server: `python app.py`
+4. Visit `http://localhost:8080` to view the dashboard.
+

--- a/app.py
+++ b/app.py
@@ -396,6 +396,10 @@ async def lifespan(app: FastAPI):
                 mqtt_client_ref.disconnect()
         except Exception:
             pass
+        try:
+            DB.close()
+        except Exception:
+            pass
 
 app = FastAPI(title="Meshtastic Telemetry (embedded UI)", lifespan=lifespan)
 if ALLOW_CORS and HAVE_CORS:


### PR DESCRIPTION
## Summary
- close SQLite database connection when application shuts down
- document setup and usage in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0c04b1438832380dca2b167ac95c1