### PR TITLE
Add nickname support and log unknown node data

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,13 @@
+
 const $nodes = document.getElementById('nodes');
 const $range = document.getElementById('range');
 const $refresh = document.getElementById('refresh');
 const $autoref = document.getElementById('autoref');
+const $nick = document.getElementById('nick');
+const $saveNick = document.getElementById('save-nick');
+const $showNick = document.getElementById('show-nick');
+
+let nodesMap = {};
 
 function fmtTs(ms){ return new Date(ms).toLocaleString(); }
 
@@ -60,18 +66,35 @@ for (const fam of Object.keys(charts)){
 async function loadNodes(){
   const res = await fetch('/api/nodes');
   const nodes = await res.json();
+  const selected = Array.from($nodes.selectedOptions).map(o => o.value);
   $nodes.innerHTML = '';
+  nodesMap = {};
+  const useNick = $showNick.checked;
   for (const n of nodes){
+    nodesMap[n.node_id] = n;
     const opt = document.createElement('option');
     opt.value = n.node_id;
-    const parts = [];
-    if (n.long_name) parts.push(n.long_name);
-    if (n.short_name && n.short_name !== n.long_name) parts.push(n.short_name);
-    if (!parts.length) parts.push(n.node_id);
-    opt.textContent = `${parts.join(' / ')} (${n.info_packets})`;
+    let label;
+    if (useNick && n.nickname) label = n.nickname;
+    else {
+      const parts = [];
+      if (n.long_name) parts.push(n.long_name);
+      if (n.short_name && n.short_name !== n.long_name) parts.push(n.short_name);
+      if (!parts.length) parts.push(n.node_id);
+      label = parts.join(' / ');
+    }
+    opt.textContent = `${label} (${n.info_packets})`;
     opt.title = `${n.node_id} — info: ${n.info_packets}`;
+    if (selected.includes(n.node_id)) opt.selected = true;
     $nodes.appendChild(opt);
   }
+  updateNickInput();
+}
+
+function updateNickInput(){
+  const id = $nodes.value;
+  const n = nodesMap[id];
+  $nick.value = n && n.nickname ? n.nickname : '';
 }
 
 async function loadData(){
@@ -80,6 +103,7 @@ async function loadData(){
   const url = new URL('/api/metrics', location.origin);
   if (names) url.searchParams.set('nodes', names);
   url.searchParams.set('since_s', since);
+  url.searchParams.set('use_nick', $showNick.checked ? '1' : '0');
   const res = await fetch(url);
   const data = await res.json();
   const series = data.series || {};
@@ -95,7 +119,20 @@ async function loadData(){
   }
 }
 
+$nodes.onchange = () => { updateNickInput(); };
 $refresh.onclick = loadData;
+$saveNick.onclick = async () => {
+  const id = $nodes.value;
+  if (!id) return;
+  await fetch('/api/nodes/nickname', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ node_id: id, nickname: $nick.value })
+  });
+  await loadNodes();
+  await loadData();
+};
+$showNick.onchange = () => { loadNodes(); loadData(); };
 $autoref.onchange = () => {
   if ($autoref.checked){
     loadData();

--- a/static/index.html
+++ b/static/index.html
@@ -33,8 +33,15 @@ small{color:#666}
       <option value="604800">Ultimi 7 giorni</option>
     </select>
   </label>
+  <label>
+    <small>Nickname</small><br/>
+    <input id="nick" type="text"/>
+  </label>
+  <button id="save-nick">Salva Nickname</button>
+
   <button id="refresh">Aggiorna</button>
   <a href="/map">Mappa</a>
+  <label><input type="checkbox" id="show-nick"/> Mostra nickname</label>
   <label style="margin-left:auto">
     <input type="checkbox" id="autoref"/> Auto-refresh (15s)
   </label>

--- a/static/map.js
+++ b/static/map.js
@@ -10,7 +10,7 @@ async function loadNodes(){
   let first = true;
   for (const n of nodes){
     if (n.lat != null && n.lon != null){
-      const name = n.long_name || n.short_name || n.node_id;
+      const name = n.nickname || n.long_name || n.short_name || n.node_id;
       const m = L.marker([n.lat, n.lon]).addTo(map);
       const last = n.last_seen ? new Date(n.last_seen*1000).toLocaleString() : '';
       const alt = n.alt != null ? `<br/>Alt: ${n.alt} m` : '';


### PR DESCRIPTION
## Summary
- store metrics from messages without a node id under an "unknown" node
- allow setting and toggling custom node nicknames
- expose nickname-aware node and metrics APIs

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1a21cbdc0832382801f2746b2c30c