### PR TITLE
Add nickname support and log unknown node data

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import json, os, re, sqlite3, threading, time
 from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 try:
@@ -125,6 +125,7 @@ def migrate():
               node_id TEXT PRIMARY KEY,
               short_name TEXT,
               long_name TEXT,
+              nickname TEXT,
               last_seen INTEGER,
               info_packets INTEGER DEFAULT 0,
               lat REAL,
@@ -147,6 +148,7 @@ def migrate():
         ncols = _cols("nodes")
         if "short_name" not in ncols: DB.execute("ALTER TABLE nodes ADD COLUMN short_name TEXT")
         if "long_name"  not in ncols: DB.execute("ALTER TABLE nodes ADD COLUMN long_name TEXT")
+        if "nickname" not in ncols: DB.execute("ALTER TABLE nodes ADD COLUMN nickname TEXT")
         if "last_seen"  not in ncols: DB.execute("ALTER TABLE nodes ADD COLUMN last_seen INTEGER")
         if "info_packets" not in ncols: DB.execute("ALTER TABLE nodes ADD COLUMN info_packets INTEGER DEFAULT 0")
         if "lat" not in ncols: DB.execute("ALTER TABLE nodes ADD COLUMN lat REAL")
@@ -159,7 +161,7 @@ def migrate():
         DB.execute("CREATE INDEX IF NOT EXISTS idx_telem_ts ON telemetry(ts)")
         DB.execute("CREATE INDEX IF NOT EXISTS idx_telem_nodeid ON telemetry(node_id)")
         DB.execute("CREATE INDEX IF NOT EXISTS idx_telem_metric ON telemetry(metric)")
-        DB.execute("CREATE INDEX IF NOT EXISTS idx_nodes_name ON nodes(COALESCE(long_name, short_name))")
+        DB.execute("CREATE INDEX IF NOT EXISTS idx_nodes_name ON nodes(COALESCE(nickname, long_name, short_name))")
         DB.commit()
 migrate()
 
@@ -179,8 +181,8 @@ def upsert_node(
     with DB_LOCK:
         DB.execute(
             """
-          INSERT INTO nodes(node_id, short_name, long_name, last_seen, info_packets, lat, lon, alt)
-          VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+          INSERT INTO nodes(node_id, short_name, long_name, nickname, last_seen, info_packets, lat, lon, alt)
+          VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(node_id) DO UPDATE SET
             short_name = COALESCE(excluded.short_name, nodes.short_name),
             long_name  = COALESCE(excluded.long_name, nodes.long_name),
@@ -191,7 +193,7 @@ def upsert_node(
             lon = COALESCE(excluded.lon, nodes.lon),
             alt = COALESCE(excluded.alt, nodes.alt)
         """,
-            (node_id, short_name, long_name, ts, inc, lat, lon, alt),
+            (node_id, short_name, long_name, None, ts, inc, lat, lon, alt),
         )
         name_to_set = long_name or short_name
         if node_id and name_to_set:
@@ -479,14 +481,15 @@ def start_mqtt():
 
         uid, sname, lname = _extract_user_info(data)
         node_id = uid or _parse_node_id(data, msg.topic)
-        if not node_id:
-            return
-
         lat, lon, alt = _extract_position(data)
         has_info = bool(uid or sname or lname)
+        if not node_id:
+            node_id = "unknown"
+            upsert_node(node_id, None, "Sconosciuto", now_s)
+        else:
+            upsert_node(node_id, sname, lname, now_s, info_packet=has_info, lat=lat, lon=lon, alt=alt)
         # registra o aggiorna sempre il nodo per permettere la selezione anche
         # quando abbiamo solo l'ID (i nomi verranno riempiti alla prima occasione)
-        upsert_node(node_id, sname, lname, now_s, info_packet=has_info, lat=lat, lon=lon, alt=alt)
 
 
         # blocchi con metriche
@@ -557,19 +560,20 @@ def api_nodes():
     with DB_LOCK:
         DB.row_factory = sqlite3.Row
         cur = DB.execute("""
-            SELECT node_id, short_name, long_name, last_seen, info_packets, lat, lon, alt
+            SELECT node_id, short_name, long_name, nickname, last_seen, info_packets, lat, lon, alt
 
-            FROM nodes ORDER BY COALESCE(long_name, short_name, node_id)
+            FROM nodes ORDER BY COALESCE(nickname, long_name, short_name, node_id)
         """)
         rows = cur.fetchall()
     out = []
     for r in rows:
-        disp = r["long_name"] or r["short_name"] or r["node_id"]
+        disp = r["nickname"] or r["long_name"] or r["short_name"] or r["node_id"]
 
         out.append({
             "node_id": r["node_id"],
             "short_name": r["short_name"],
             "long_name": r["long_name"],
+            "nickname": r["nickname"],
             "display_name": disp,
             "last_seen": r["last_seen"],
             "info_packets": r["info_packets"],
@@ -580,13 +584,26 @@ def api_nodes():
 
     return JSONResponse(out)
 
+
+@app.post("/api/nodes/nickname")
+async def api_set_nickname(req: Request):
+    data = await req.json()
+    node_id = data.get("node_id")
+    nickname = (data.get("nickname") or "").strip() or None
+    if not node_id:
+        return JSONResponse({"error": "node_id required"}, status_code=400)
+    with DB_LOCK:
+        DB.execute("UPDATE nodes SET nickname=? WHERE node_id=?", (nickname, node_id))
+        DB.commit()
+    return JSONResponse({"status": "ok"})
+
 def _resolve_ids(names: List[str]) -> List[str]:
     if not names: return []
     qs = ",".join("?" for _ in names)
     with DB_LOCK:
         cur = DB.execute(f"""
             SELECT node_id FROM nodes
-            WHERE COALESCE(long_name, short_name, node_id) IN ({qs})
+            WHERE COALESCE(nickname, long_name, short_name, node_id) IN ({qs})
         """, (*names,))
         ids = [r[0] for r in cur.fetchall()]
     for n in names:
@@ -598,10 +615,12 @@ def _resolve_ids(names: List[str]) -> List[str]:
 def api_metrics(
     nodes: Optional[str] = Query(default=None, description="Nomi visuali o node_id separati da virgola"),
     since_s: int = Query(default=24*3600, ge=0, le=30*24*3600),
+    use_nick: int = Query(default=0, ge=0, le=1),
 ):
     since_ts = int(time.time()) - since_s
     selected = [s.strip() for s in (nodes.split(",") if nodes else []) if s.strip()]
     ids = _resolve_ids(selected) if selected else []
+    name_expr = "COALESCE(nodes.nickname, telemetry.node_name, nodes.long_name, nodes.short_name, telemetry.node_id)" if use_nick else "COALESCE(telemetry.node_name, nodes.long_name, nodes.short_name, telemetry.node_id)"
 
     with DB_LOCK:
         DB.row_factory = sqlite3.Row
@@ -611,7 +630,7 @@ def api_metrics(
                 SELECT
                     telemetry.ts            AS ts,
                     telemetry.node_id       AS node_id,
-                    COALESCE(telemetry.node_name, nodes.long_name, nodes.short_name, telemetry.node_id) AS disp,
+                    {name_expr} AS disp,
                     telemetry.metric        AS metric,
                     telemetry.value         AS value
                 FROM telemetry
@@ -620,11 +639,11 @@ def api_metrics(
                 ORDER BY telemetry.ts ASC
             """, (since_ts, *ids))
         else:
-            cur = DB.execute("""
+            cur = DB.execute(f"""
                 SELECT
                     telemetry.ts            AS ts,
                     telemetry.node_id       AS node_id,
-                    COALESCE(telemetry.node_name, nodes.long_name, nodes.short_name, telemetry.node_id) AS disp,
+                    {name_expr} AS disp,
                     telemetry.metric        AS metric,
                     telemetry.value         AS value
                 FROM telemetry

--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,13 @@
+
 const $nodes = document.getElementById('nodes');
 const $range = document.getElementById('range');
 const $refresh = document.getElementById('refresh');
 const $autoref = document.getElementById('autoref');
+const $nick = document.getElementById('nick');
+const $saveNick = document.getElementById('save-nick');
+const $showNick = document.getElementById('show-nick');
+
+let nodesMap = {};
 
 function fmtTs(ms){ return new Date(ms).toLocaleString(); }
 
@@ -60,18 +66,36 @@ for (const fam of Object.keys(charts)){
 async function loadNodes(){
   const res = await fetch('/api/nodes');
   const nodes = await res.json();
+  const selected = Array.from($nodes.selectedOptions).map(o => o.value);
   $nodes.innerHTML = '';
+  nodesMap = {};
+  const useNick = $showNick.checked;
   for (const n of nodes){
+    nodesMap[n.node_id] = n;
     const opt = document.createElement('option');
     opt.value = n.node_id;
-    const parts = [];
-    if (n.long_name) parts.push(n.long_name);
-    if (n.short_name && n.short_name !== n.long_name) parts.push(n.short_name);
-    if (!parts.length) parts.push(n.node_id);
-    opt.textContent = `${parts.join(' / ')} (${n.info_packets})`;
+    let label;
+    if (useNick){
+      label = n.display_name;
+    } else {
+      const parts = [];
+      if (n.long_name) parts.push(n.long_name);
+      if (n.short_name && n.short_name !== n.long_name) parts.push(n.short_name);
+      if (!parts.length) parts.push(n.node_id);
+      label = parts.join(' / ');
+    }
+    opt.textContent = `${label} (${n.info_packets})`;
     opt.title = `${n.node_id} — info: ${n.info_packets}`;
+    if (selected.includes(n.node_id)) opt.selected = true;
     $nodes.appendChild(opt);
   }
+  updateNickInput();
+}
+
+function updateNickInput(){
+  const id = $nodes.value;
+  const n = nodesMap[id];
+  $nick.value = n && n.nickname ? n.nickname : '';
 }
 
 async function loadData(){
@@ -80,6 +104,7 @@ async function loadData(){
   const url = new URL('/api/metrics', location.origin);
   if (names) url.searchParams.set('nodes', names);
   url.searchParams.set('since_s', since);
+  url.searchParams.set('use_nick', $showNick.checked ? '1' : '0');
   const res = await fetch(url);
   const data = await res.json();
   const series = data.series || {};
@@ -95,7 +120,20 @@ async function loadData(){
   }
 }
 
+$nodes.onchange = () => { updateNickInput(); };
 $refresh.onclick = loadData;
+$saveNick.onclick = async () => {
+  const id = $nodes.value;
+  if (!id) return;
+  await fetch('/api/nodes/nickname', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ node_id: id, nickname: $nick.value })
+  });
+  await loadNodes();
+  await loadData();
+};
+$showNick.onchange = () => { loadNodes(); loadData(); };
 $autoref.onchange = () => {
   if ($autoref.checked){
     loadData();

--- a/static/index.html
+++ b/static/index.html
@@ -33,8 +33,15 @@ small{color:#666}
       <option value="604800">Ultimi 7 giorni</option>
     </select>
   </label>
+  <label>
+    <small>Nickname</small><br/>
+    <input id="nick" type="text"/>
+  </label>
+  <button id="save-nick">Salva Nickname</button>
+
   <button id="refresh">Aggiorna</button>
   <a href="/map">Mappa</a>
+  <label><input type="checkbox" id="show-nick"/> Mostra nickname</label>
   <label style="margin-left:auto">
     <input type="checkbox" id="autoref"/> Auto-refresh (15s)
   </label>

--- a/static/map.js
+++ b/static/map.js
@@ -10,7 +10,7 @@ async function loadNodes(){
   let first = true;
   for (const n of nodes){
     if (n.lat != null && n.lon != null){
-      const name = n.long_name || n.short_name || n.node_id;
+      const name = n.display_name;
       const m = L.marker([n.lat, n.lon]).addTo(map);
       const last = n.last_seen ? new Date(n.last_seen*1000).toLocaleString() : '';
       const alt = n.alt != null ? `<br/>Alt: ${n.alt} m` : '';


### PR DESCRIPTION
## Summary
- store metrics from messages without a node id under an "unknown" node
- allow setting and toggling custom node nicknames
- expose nickname-aware node and metrics APIs
- refresh UI elements to show updated nicknames

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1a21cbdc0832382801f2746b2c30c