### PR TITLE
Add MQTT message processing helper and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -450,6 +450,50 @@ def try_decode_protobuf(payload: bytes) -> Optional[Dict[str, Any]]:
         pass
     return None
 
+# ---------- MQTT message processing (shared) ----------
+def process_mqtt_message(topic: str, payload: bytes) -> None:
+    """Elabora un messaggio MQTT in formato JSON o Protobuf.
+
+    Questo helper permette di testare la logica di parsing senza
+    dipendere da un broker MQTT reale.  Il comportamento replica quello
+    del callback ``on_message`` definito in ``start_mqtt``.
+    """
+
+    now_s = int(time.time())
+    # Prova JSON, poi Protobuf se abilitato
+    data = _json_loads(payload)
+    if not isinstance(data, dict) and PROTOBUF_DECODE and HAVE_MESHTASTIC:
+        data = try_decode_protobuf(payload)
+    if not isinstance(data, dict):
+        return
+
+    uid, sname, lname = _extract_user_info(data)
+    node_id = uid or _parse_node_id(data, topic)
+    lat, lon, alt = _extract_position(data)
+    has_info = bool(uid or sname or lname)
+    if not node_id:
+        node_id = "unknown"
+        upsert_node(node_id, None, "Sconosciuto", now_s)
+    else:
+        upsert_node(node_id, sname, lname, now_s,
+                    info_packet=has_info, lat=lat, lon=lon, alt=alt)
+
+    candidates: List[Dict[str, Any]] = []
+    if "payload" in data and isinstance(data["payload"], dict):
+        candidates.append(data["payload"])
+    if any(k in data for k in ("environment_metrics", "device_metrics", "power_metrics")):
+        candidates.append(data)
+    if not candidates:
+        candidates.append(data)
+
+    for d in candidates:
+        flat_all = flatten_numeric(d)
+        flat = normalize_flat(flat_all)
+        if not flat:
+            continue
+        for metric, value in flat.items():
+            store_metric(now_s, node_id, metric, value)
+
 # ---------- MQTT (una sola istanza via lifespan) ----------
 def start_mqtt():
     proto = MQTTv311 if MQTT_PROTO == "v311" else MQTTv5
@@ -486,44 +530,7 @@ def start_mqtt():
         print(f"[MQTT] Disconnected rc={reason_code}. Retry automatico attivo.")
 
     def on_message(client, userdata, msg):
-        now_s = int(time.time())
-        # Prova JSON, poi Protobuf se abilitato
-        data = _json_loads(msg.payload)
-        if not isinstance(data, dict) and PROTOBUF_DECODE and HAVE_MESHTASTIC:
-            data = try_decode_protobuf(msg.payload)
-        if not isinstance(data, dict):
-            return
-
-
-        uid, sname, lname = _extract_user_info(data)
-        node_id = uid or _parse_node_id(data, msg.topic)
-        lat, lon, alt = _extract_position(data)
-        has_info = bool(uid or sname or lname)
-        if not node_id:
-            node_id = "unknown"
-            upsert_node(node_id, None, "Sconosciuto", now_s)
-        else:
-            upsert_node(node_id, sname, lname, now_s, info_packet=has_info, lat=lat, lon=lon, alt=alt)
-        # registra o aggiorna sempre il nodo per permettere la selezione anche
-        # quando abbiamo solo l'ID (i nomi verranno riempiti alla prima occasione)
-
-
-        # blocchi con metriche
-        candidates: List[Dict[str, Any]] = []
-        if "payload" in data and isinstance(data["payload"], dict):
-            candidates.append(data["payload"])
-        if any(k in data for k in ("environment_metrics", "device_metrics", "power_metrics")):
-            candidates.append(data)
-        if not candidates:
-            candidates.append(data)
-
-        for d in candidates:
-            flat_all = flatten_numeric(d)
-            flat = normalize_flat(flat_all)
-            if not flat:
-                continue
-            for metric, value in flat.items():
-                store_metric(now_s, node_id, metric, value)
+        process_mqtt_message(msg.topic, msg.payload)
 
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect

--- a/tests/test.config.yml
+++ b/tests/test.config.yml
@@ -1,0 +1,13 @@
+mqtt:
+  host: "localhost"
+  port: 1883
+  client_id: "test-client"
+  protocol: "v311"
+  topics: ["#"]
+storage:
+  sqlite_path: ":memory:"
+web:
+  host: "0.0.0.0"
+  port: 8080
+  allow_cors: true
+protobuf_decode: true

--- a/tests/test_mqtt_processing.py
+++ b/tests/test_mqtt_processing.py
@@ -1,0 +1,47 @@
+import os
+import importlib
+import json
+
+# Config per l'app: puntiamo al file di test
+os.environ['TP_CONFIG'] = os.path.join(os.path.dirname(__file__), 'test.config.yml')
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import app  # noqa: E402
+
+# Garantiamo che l'app utilizzi la nuova configurazione
+importlib.reload(app)
+
+
+def reset_db():
+    with app.DB_LOCK:
+        app.DB.execute('DELETE FROM telemetry')
+        app.DB.execute('DELETE FROM nodes')
+        app.DB.commit()
+
+
+def test_process_json_message():
+    reset_db()
+    msg = {
+        'environment_metrics': {'temperature': 23.5},
+        'user': {'id': 'abcd'}
+    }
+    payload = json.dumps(msg).encode()
+    app.process_mqtt_message('msh/test', payload)
+    with app.DB_LOCK:
+        rows = app.DB.execute('SELECT node_id, metric, value FROM telemetry').fetchall()
+    assert rows == [('abcd', 'temperature', 23.5)]
+
+
+def test_process_proto_message():
+    reset_db()
+    from meshtastic import telemetry_pb2
+
+    t = telemetry_pb2.Telemetry()
+    t.environment_metrics.temperature = 31.5
+    payload = t.SerializeToString()
+    app.process_mqtt_message('msh/abcdef/telemetry', payload)
+    with app.DB_LOCK:
+        rows = app.DB.execute('SELECT node_id, metric, value FROM telemetry').fetchall()
+    assert rows == [('abcdef', 'temperature', 31.5)]


### PR DESCRIPTION
## Summary
- expose `process_mqtt_message` helper to reuse parsing logic outside of MQTT callbacks
- test JSON and protobuf telemetry messages using Meshtastic simulator

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b57221df3c8323a837c977ff304b47