### PR TITLE
Decode nested MeshPacket protobuf payloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -414,23 +414,37 @@ def normalize_flat(flat: Dict[str, float]) -> Dict[str, float]:
 def pb_to_dict(msg) -> Dict[str, Any]:
     return MessageToDict(msg, preserving_proto_field_name=True)
 
-def try_decode_protobuf(payload: bytes) -> Optional[Dict[str, Any]]:
+def try_decode_protobuf(payload: bytes, *, _nested: bool = False) -> Optional[Dict[str, Any]]:
     """Best‑effort decoding of Meshtastic protobuf payloads.
 
     The MQTT broker can forward either the raw ``MeshPacket`` binary or the
     already decoded submessages (``Telemetry``, ``User``, ``Position`` …).  We
     try each possibility in order and return a ``dict`` representation of the
     first message type that parses successfully.
+
+    When decoding a full ``MeshPacket`` we also attempt to decode the
+    ``decoded.payload`` field into a nested dictionary so that callers can work
+    with the final application message directly.
     """
 
     # Full MeshPacket (contains portnum + decoded payload)
-    try:
-        pkt = mesh_pb2.MeshPacket()
-        pkt.ParseFromString(payload)
-        if len(pkt.ListFields()) > 0:
-            return pb_to_dict(pkt)
-    except Exception:
-        pass
+    if not _nested:
+        try:
+            pkt = mesh_pb2.MeshPacket()
+            pkt.ParseFromString(payload)
+            if len(pkt.ListFields()) > 0:
+                inner: Optional[Dict[str, Any]] = None
+                try:
+                    if pkt.decoded and pkt.decoded.payload:
+                        inner = try_decode_protobuf(pkt.decoded.payload, _nested=True)
+                except Exception:
+                    inner = None
+                pkt_dict = pb_to_dict(pkt)
+                if inner:
+                    pkt_dict.setdefault("decoded", {})["payload"] = inner
+                return pkt_dict
+        except Exception:
+            pass
     # Telemetry
     try:
         t = telemetry_pb2.Telemetry()


### PR DESCRIPTION
## Summary
- recursively decode `MeshPacket.decoded.payload` so nested protobufs are parsed
- add regression test for handling telemetry inside full MeshPacket

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5770295288323a7bb23b27c9737aa