### PR TITLE
Add favicon and improve node API stability

### DIFF
--- a/app.py
+++ b/app.py
@@ -577,6 +577,20 @@ if ALLOW_CORS and HAVE_CORS:
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
+
+@app.get("/favicon.ico", include_in_schema=False)
+def favicon():
+    """Serve the browser favicon.
+
+    Alcuni browser richiedono ``/favicon.ico`` anche se non
+    specificato nei template. Per evitare errori 404
+    restituiamo un'icona SVG testuale.
+    """
+    return FileResponse(
+        os.path.join("static", "favicon.svg"),
+        media_type="image/svg+xml",
+    )
+
 @app.get("/")
 def ui():
     return FileResponse(os.path.join("static", "index.html"))
@@ -588,13 +602,19 @@ def map_ui():
 @app.get("/api/nodes")
 def api_nodes():
     with DB_LOCK:
+        old_factory = DB.row_factory
         DB.row_factory = sqlite3.Row
-        cur = DB.execute("""
+        try:
+            cur = DB.execute(
+                """
             SELECT node_id, short_name, long_name, nickname, last_seen, info_packets, lat, lon, alt
 
             FROM nodes ORDER BY COALESCE(nickname, long_name, short_name, node_id)
-        """)
-        rows = cur.fetchall()
+        """
+            )
+            rows = cur.fetchall()
+        finally:
+            DB.row_factory = old_factory
     out = []
     for r in rows:
         disp = r["nickname"] or r["long_name"] or r["short_name"] or r["node_id"]
@@ -653,10 +673,13 @@ def api_metrics(
     name_expr = "COALESCE(nodes.nickname, telemetry.node_name, nodes.long_name, nodes.short_name, telemetry.node_id)" if use_nick else "COALESCE(telemetry.node_name, nodes.long_name, nodes.short_name, telemetry.node_id)"
 
     with DB_LOCK:
+        old_factory = DB.row_factory
         DB.row_factory = sqlite3.Row
-        if ids:
-            qs = ",".join("?" for _ in ids)
-            cur = DB.execute(f"""
+        try:
+            if ids:
+                qs = ",".join("?" for _ in ids)
+                cur = DB.execute(
+                    f"""
                 SELECT
                     telemetry.ts            AS ts,
                     telemetry.node_id       AS node_id,
@@ -667,9 +690,12 @@ def api_metrics(
                 LEFT JOIN nodes ON nodes.node_id = telemetry.node_id
                 WHERE telemetry.ts >= ? AND telemetry.node_id IN ({qs})
                 ORDER BY telemetry.ts ASC
-            """, (since_ts, *ids))
-        else:
-            cur = DB.execute(f"""
+            """,
+                    (since_ts, *ids),
+                )
+            else:
+                cur = DB.execute(
+                    f"""
                 SELECT
                     telemetry.ts            AS ts,
                     telemetry.node_id       AS node_id,
@@ -680,8 +706,12 @@ def api_metrics(
                 LEFT JOIN nodes ON nodes.node_id = telemetry.node_id
                 WHERE telemetry.ts >= ?
                 ORDER BY telemetry.ts ASC
-            """, (since_ts,))
-        rows = cur.fetchall()
+            """,
+                    (since_ts,),
+                )
+            rows = cur.fetchall()
+        finally:
+            DB.row_factory = old_factory
 
     fams = {"temperature": [], "humidity": [], "pressure": [], "voltage": [], "current": []}
     acc: Dict[Tuple[str, str], List[Dict[str, float]]] = {}

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#2f855a"/>
+  <text x="8" y="12" font-size="12" text-anchor="middle" fill="#fff" font-family="Arial, Helvetica, sans-serif">M</text>
+</svg>

--- a/static/index.html
+++ b/static/index.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg"/>
 <style>
 :root{
   --bd:#334155;

--- a/static/map.html
+++ b/static/map.html
@@ -3,6 +3,7 @@
 <meta charset="utf-8"/><title>Mappa Nodi</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg"/>
 <style>
 :root{
   --bd:#334155;


### PR DESCRIPTION
## Summary
- serve an SVG favicon and link it in HTML to avoid binary assets
- restore SQLite row factory after queries to avoid side effects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b573e4002483238623f8715059e22d