### PR TITLE
Refresh node list automatically

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,16 @@ MQTT_PROTO = (cfg["mqtt"].get("protocol", "v311") or "v311").lower()
 MQTT_TOPICS = _normalize_topics(cfg["mqtt"].get("topics"))
 TLS_CFG = cfg["mqtt"].get("tls") or {"enabled": False}
 
-DB_PATH = cfg["storage"].get("sqlite_path")
+# Percorso SQLite relativo al file di config
+_raw_db_path = cfg["storage"].get("sqlite_path")
+if not _raw_db_path:
+    raise SystemExit("[CFG] storage.sqlite_path mancante in config.yml")
+if _raw_db_path == ":memory:":
+    DB_PATH = _raw_db_path
+else:
+    cfg_dir = os.path.dirname(os.path.abspath(CFG_PATH))
+    DB_PATH = os.path.abspath(os.path.join(cfg_dir, _raw_db_path))
+
 WEB_HOST = cfg["web"].get("host", "0.0.0.0")
 WEB_PORT = int(cfg["web"].get("port", 8080))
 ALLOW_CORS = bool(cfg["web"].get("allow_cors", True))
@@ -61,6 +70,7 @@ print(f"[CFG] Loaded: {os.path.abspath(CFG_PATH)}")
 print(f"[CFG] MQTT host={MQTT_HOST} port={MQTT_PORT} client_id={MQTT_CLIENT_ID} proto={MQTT_PROTO}")
 print(f"[CFG] Topics (raw type={type(cfg['mqtt'].get('topics')).__name__}): {cfg['mqtt'].get('topics')!r}")
 print(f"[CFG] Topics (normalized): {MQTT_TOPICS}")
+print(f"[CFG] SQLite DB: {DB_PATH}")
 
 if not MQTT_HOST or not MQTT_PORT:
     raise SystemExit("[CFG] mqtt.host/port mancanti in config.yml")

--- a/static/app.js
+++ b/static/app.js
@@ -151,7 +151,7 @@ async function loadData(){
 }
 
 $nodes.onchange = () => { updateNickInput(); };
-$refresh.onclick = loadData;
+$refresh.onclick = () => { loadNodes(); loadData(); };
 $saveNick.onclick = async () => {
   const id = $nodes.value;
   if (!id) return;
@@ -166,8 +166,9 @@ $saveNick.onclick = async () => {
 $showNick.onchange = () => { loadNodes(); loadData(); };
 $autoref.onchange = () => {
   if ($autoref.checked){
-    loadData();
-    window._timer = setInterval(loadData, 15000);
+    const tick = () => { loadNodes(); loadData(); };
+    tick();
+    window._timer = setInterval(tick, 15000);
   } else {
     clearInterval(window._timer);
   }


### PR DESCRIPTION
## Summary
- refresh node dropdown when manually or auto updating data
- resolve SQLite path relative to config so stored nodes remain visible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5900c5c488323b1b595e62051fafa