### PR TITLE
Expand nodes column to full page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -51,13 +51,16 @@ select{min-width:260px}
   display:flex;
   gap:16px;
   margin-top:12px;
-  align-items:flex-start;
+  align-items:stretch;
+  height:calc(100vh - 120px);
 }
 .sidebar{
   min-width:260px;
+  height:100%;
 }
 #nodes{
   width:100%;
+  height:100%;
 }
 .toggles{
   margin-top:8px;
@@ -112,7 +115,7 @@ small{color:#94a3b8}
   <aside class="sidebar">
     <label>
       <small>Nodi (Long/Short/ID)</small><br/>
-      <select id="nodes" multiple size="15"></select>
+      <select id="nodes" multiple></select>
     </label>
   </aside>
   <div class="content" style="flex:1">


### PR DESCRIPTION
## Summary
- Extend nodes column to fill available page height
- Remove fixed node list size

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a34e532c8323b1c0d2083004647c