### PR TITLE
Use compact node labels in charts

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -43,7 +43,7 @@ function mkChart(ctx, yLabel){
       interaction: { mode: 'nearest', intersect: false },
       elements: { point: { radius: 3, borderColor: _accent, backgroundColor: _accent } },
       plugins: {
-        legend: { position: 'bottom' },
+        legend: { position: 'bottom', labels: { usePointStyle: true, boxWidth: 8, boxHeight: 8 } },
         tooltip: {
           callbacks: {
             title: items => fmtTs(items[0].raw.x),
@@ -159,9 +159,11 @@ async function loadData(){
     const unit = units[fam] || '';
     const ds = (series[fam] || []).map(s => {
       const last = s.data.length ? s.data[s.data.length - 1].y.toFixed(2) : 'n/a';
-      const node = s.label;
+      const nodeId = s.node_id;
+      const short = nodesMap[nodeId]?.short_name || nodeId.slice(-4);
+      const node = short;
       const label = showNode ? `${last} ${unit} ${node}` : `${last} ${unit}`;
-      const color = colorFor(node);
+      const color = colorFor(nodeId);
       return { label, data: s.data, node, unit, showNode, borderColor: color, backgroundColor: color };
     });
     charts[fam].data.datasets = ds;


### PR DESCRIPTION
## Summary
- Include node_id in metrics API output to allow compact labels
- Show short node names (or last 4 of id) and round legend markers in charts

## Testing
- `pytest tests/test_mqtt_processing.py tests/test_meshtasticator_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b62813c0108323a3281771dc111902