### PR TITLE
Store all MQTT packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js.
 
+All MQTT packets, including text messages, waypoints and other application types, are stored in the `messages` table for future use alongside the parsed telemetry and traceroute information.
+
 ## Quick start
 
 1. Copy `example.config.yml` to `config.yml` and adjust the broker settings.

--- a/database.py
+++ b/database.py
@@ -98,12 +98,25 @@ def migrate() -> None:
             """,
         )
 
+        DB.execute(
+            """
+            CREATE TABLE IF NOT EXISTS messages (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              ts INTEGER,
+              node_id TEXT,
+              portnum TEXT,
+              raw_json TEXT
+            )
+            """,
+        )
+
         # indici
         DB.execute("CREATE INDEX IF NOT EXISTS idx_telem_ts ON telemetry(ts)")
         DB.execute("CREATE INDEX IF NOT EXISTS idx_telem_nodeid ON telemetry(node_id)")
         DB.execute("CREATE INDEX IF NOT EXISTS idx_telem_metric ON telemetry(metric)")
         DB.execute("CREATE INDEX IF NOT EXISTS idx_nodes_name ON nodes(COALESCE(nickname, long_name, short_name))")
         DB.execute("CREATE INDEX IF NOT EXISTS idx_traceroutes_ts ON traceroutes(ts)")
+        DB.execute("CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(ts)")
         DB.commit()
 
 


### PR DESCRIPTION
## Summary
- Capture every MQTT packet by persisting its decoded JSON in a new `messages` table
- Add table migration and indexing to hold port number and raw data
- Include tests for storing generic text packets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b804b352648323947ffe180f82f628