### PR TITLE
Handle camelCase metrics and ensure pressure extraction

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -430,10 +430,18 @@ def _store_metrics(node_id: str, now_s: int, data: Dict[str, Any]) -> None:
     """Flatten metrics from a message and store them in the DB."""
 
     candidates: List[Dict[str, Any]] = []
-    if "payload" in data and isinstance(data["payload"], dict):
+    if isinstance(data.get("payload"), dict):
         candidates.append(data["payload"])
-    if any(k in data for k in ("environment_metrics", "device_metrics", "power_metrics")):
-        candidates.append(data)
+    for k in (
+        "environment_metrics",
+        "device_metrics",
+        "power_metrics",
+        "environmentMetrics",
+        "deviceMetrics",
+        "powerMetrics",
+    ):
+        if isinstance(data.get(k), dict):
+            candidates.append(data[k])
     if not candidates:
         candidates.append(data)
 

--- a/tests/test_mqtt_processing.py
+++ b/tests/test_mqtt_processing.py
@@ -53,6 +53,25 @@ def test_process_json_camelcase_env():
     assert rows == [('humidity', 40.5), ('pressure', 1001.1)]
 
 
+def test_nodeinfo_pressure_extraction():
+    """Extract pressure metric from full NodeInfo messages."""
+    reset_db()
+    msg = {
+        '$typeName': 'meshtastic.NodeInfo',
+        'user': {'id': 'node1'},
+        'environmentMetrics': {
+            'temperature': 25.7,
+            'barometricPressure': 1017.6,
+        },
+        'deviceMetrics': {'batteryLevel': 88},
+    }
+    payload = json.dumps(msg).encode()
+    app.process_mqtt_message('msh/node1/info', payload)
+    with app.DB_LOCK:
+        rows = app.DB.execute('SELECT metric, value FROM telemetry').fetchall()
+    assert ('pressure', 1017.6) in rows
+
+
 def test_process_proto_message():
     reset_db()
     from meshtastic import telemetry_pb2


### PR DESCRIPTION
## Summary
- Parse metric blocks provided with camelCase keys (environmentMetrics, deviceMetrics, powerMetrics)
- Add test demonstrating pressure extraction from NodeInfo messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b94235facc83239ffee26582d36ca4