### PR TITLE
Display traceroute links on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MeshPlotter
 
-MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js.
+MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js. A map view illustrates node positions and their traceroute connections.
 
 All MQTT packets, including text messages, waypoints and other application types, are stored in the `messages` table for future use alongside the parsed telemetry and traceroute information.
 
@@ -10,4 +10,5 @@ All MQTT packets, including text messages, waypoints and other application types
 2. Install dependencies: `pip install -r requirements.txt`
 3. Start the server: `python app.py`
 4. Visit `http://localhost:8080` to view the dashboard.
+5. Visit `http://localhost:8080/map` to see nodes and traceroute links on a map.
 

--- a/static/map.js
+++ b/static/map.js
@@ -6,6 +6,7 @@ L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
 
 let nodes = [];
 const routeLines = [];
+const routeMarkers = new Map();
 let focusLine = null;
 
 async function loadNodes(){
@@ -38,23 +39,32 @@ async function loadTraceroutes(){
     }
     if (path.length >= 2){
       const line = L.polyline(path, {color:'#ff6d00', weight:2}).addTo(map);
+      const markers = path.map(pt => L.circleMarker(pt, {radius:4, color:'#ff6d00'}).addTo(map));
       line.bindTooltip(`${r.hop_count} hop${r.hop_count===1?'':'s'}`, {permanent:true});
       line.on('click', () => highlightRoute(line));
       routeLines.push(line);
+      routeMarkers.set(line, markers);
     }
   }
 }
 
 function highlightRoute(line){
   if (focusLine === line){
-    routeLines.forEach(l => { if (!map.hasLayer(l)) l.addTo(map).setStyle({color:'#ff6d00', weight:2}); });
+    routeLines.forEach(l => {
+      if (!map.hasLayer(l)){
+        l.addTo(map).setStyle({color:'#ff6d00', weight:2});
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#ff6d00'}));
+      }
+    });
     focusLine = null;
   } else {
     routeLines.forEach(l => {
       if (l === line){
         l.setStyle({color:'#0ff', weight:4}).bringToFront();
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#0ff'}).bringToFront());
       } else {
         map.removeLayer(l);
+        routeMarkers.get(l).forEach(m => map.removeLayer(m));
       }
     });
     focusLine = line;


### PR DESCRIPTION
## Summary
- Draw traceroute paths on the map with polylines and hop markers
- Document map view for visualizing traceroute connections

## Testing
- `python -m pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'mosquitto')*


------
https://chatgpt.com/codex/tasks/task_e_68b960b5bf88832396d52a472067b358