### PR TITLE
Handle multi-channel power metrics

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -239,6 +239,7 @@ _RE_ENV = re.compile(
 )
 _RE_DEV = re.compile(r'(?:^|\.)(device_?metrics)\.(voltage)\b')
 _RE_PWR = re.compile(r'(?:^|\.)(power_?metrics)\.(bus_voltage|shunt_voltage|current|current_ma|current_a)\b')
+_RE_PWR_CH = re.compile(r'(?:^|\.)(ch\d+_(?:voltage|current|current_ma|current_a))\b')
 _RE_GENERIC = re.compile(
     r'(?:^|\.)(temp(?:erature)?|hum(?:idity)?|relativehumidity|'
     r'press(?:ure)?|barometricpressure|volt(?:age)?|current(?:_ma|_a)?)\b',
@@ -274,6 +275,17 @@ def _normalize_metric(k: str, v: float) -> Optional[Tuple[str, float]]:
             return ("current", v)
         if f == "current_ma":
             return ("current", v)
+    m = _RE_PWR_CH.search(k_low)
+    if m:
+        raw = m.group(1)
+        if raw.endswith("_voltage"):
+            return (raw, v)
+        if raw.endswith("_current_ma"):
+            return (raw.replace("_current_ma", "_current"), v)
+        if raw.endswith("_current_a"):
+            return (raw.replace("_current_a", "_current"), v * 1000)
+        if raw.endswith("_current"):
+            return (raw, v)
     if "config." in k_low or "prefs." in k_low:
         return None
     if _RE_GENERIC.search(k_low):

--- a/tests/test_mqtt_processing.py
+++ b/tests/test_mqtt_processing.py
@@ -36,6 +36,31 @@ def test_process_json_message():
     assert rows == [('abcd', 'temperature', 23.5)]
 
 
+def test_process_power_metrics_channels():
+    reset_db()
+    msg = {
+        'power_metrics': {
+            'ch1_voltage': 1.1,
+            'ch2_voltage': 2.2,
+            'ch3_voltage': 3.3,
+            'ch1_current': 10.0,
+            'ch2_current': 20.0,
+            'ch3_current': 30.0,
+        },
+        'user': {'id': 'abcd'}
+    }
+    payload = json.dumps(msg).encode()
+    app.process_mqtt_message('msh/test', payload)
+    with app.DB_LOCK:
+        rows = sorted(app.DB.execute('SELECT metric, value FROM telemetry').fetchall())
+    assert ('ch1_voltage', 1.1) in rows
+    assert ('ch2_voltage', 2.2) in rows
+    assert ('ch3_voltage', 3.3) in rows
+    assert ('ch1_current', 10.0) in rows
+    assert ('ch2_current', 20.0) in rows
+    assert ('ch3_current', 30.0) in rows
+
+
 def test_process_json_camelcase_env():
     """Support camelCase environmentMetrics keys for humidity/pressure."""
     reset_db()


### PR DESCRIPTION
## Summary
- normalize channelized power metrics (ch1/2/3 voltage and current)
- test storing and retrieving multi-channel power readings

## Testing
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `apt-get install -y mosquitto >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96889ab8483239d5bcab0141321a9