### PR TITLE
Display traceroute links on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MeshPlotter
 
-MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js.
+MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js. A map view illustrates node positions and their traceroute connections.
 
 All MQTT packets, including text messages, waypoints and other application types, are stored in the `messages` table for future use alongside the parsed telemetry and traceroute information.
 
@@ -10,4 +10,6 @@ All MQTT packets, including text messages, waypoints and other application types
 2. Install dependencies: `pip install -r requirements.txt`
 3. Start the server: `python app.py`
 4. Visit `http://localhost:8080` to view the dashboard.
+5. Visit `http://localhost:8080/map` to see nodes and traceroute links on a map.
+6. Visit `http://localhost:8080/traceroutes` for a per-node traceroute summary.
 

--- a/api.py
+++ b/api.py
@@ -69,6 +69,11 @@ def map_ui():
     return FileResponse(os.path.join("static", "map.html"))
 
 
+@app.get("/traceroutes")
+def traceroutes_ui():
+    return FileResponse(os.path.join("static", "traceroutes.html"))
+
+
 @app.get("/api/nodes")
 def api_nodes():
     with DB_LOCK:

--- a/static/index.html
+++ b/static/index.html
@@ -104,6 +104,7 @@ small{color:#94a3b8}
   <button id="save-nick">Salva Nickname</button>
   <button id="refresh">Aggiorna</button>
   <a href="/map">Mappa</a>
+  <a href="/traceroutes">Traceroute</a>
   <label><input type="checkbox" id="show-nick" checked/> Mostra nickname</label>
   <label style="margin-left:auto">
     <input type="checkbox" id="autoref" checked/> Auto-refresh (15s)

--- a/static/map.js
+++ b/static/map.js
@@ -6,6 +6,7 @@ L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
 
 let nodes = [];
 const routeLines = [];
+const routeMarkers = new Map();
 let focusLine = null;
 
 async function loadNodes(){
@@ -38,23 +39,32 @@ async function loadTraceroutes(){
     }
     if (path.length >= 2){
       const line = L.polyline(path, {color:'#ff6d00', weight:2}).addTo(map);
+      const markers = path.map(pt => L.circleMarker(pt, {radius:4, color:'#ff6d00'}).addTo(map));
       line.bindTooltip(`${r.hop_count} hop${r.hop_count===1?'':'s'}`, {permanent:true});
       line.on('click', () => highlightRoute(line));
       routeLines.push(line);
+      routeMarkers.set(line, markers);
     }
   }
 }
 
 function highlightRoute(line){
   if (focusLine === line){
-    routeLines.forEach(l => { if (!map.hasLayer(l)) l.addTo(map).setStyle({color:'#ff6d00', weight:2}); });
+    routeLines.forEach(l => {
+      if (!map.hasLayer(l)){
+        l.addTo(map).setStyle({color:'#ff6d00', weight:2});
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#ff6d00'}));
+      }
+    });
     focusLine = null;
   } else {
     routeLines.forEach(l => {
       if (l === line){
         l.setStyle({color:'#0ff', weight:4}).bringToFront();
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#0ff'}).bringToFront());
       } else {
         map.removeLayer(l);
+        routeMarkers.get(l).forEach(m => map.removeLayer(m));
       }
     });
     focusLine = line;

--- a/static/traceroutes.html
+++ b/static/traceroutes.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="it"><head>
-<meta charset="utf-8"/><title>Mappa Nodi</title>
+<meta charset="utf-8"/>
+<title>Traceroutes</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg"/>
 <style>
 :root{
@@ -28,21 +28,18 @@ header{
   box-shadow:0 1px 2px rgba(0,0,0,0.5);
 }
 header a{color:var(--accent);text-decoration:none}
-#map{
-  height:90vh;
-  margin:0 16px 16px;
-  border:1px solid var(--bd);
-  border-radius:8px;
-}
+section{margin:16px}
+section h3{margin:16px 0 8px}
+table{width:100%;border-collapse:collapse}
+th,td{padding:4px 8px;border-bottom:1px solid var(--bd);text-align:left}
 </style>
 </head>
 <body>
 <header>
-  <h2 style="margin:0">Mappa Nodi</h2>
+  <h2 style="margin:0">Traceroutes</h2>
   <a href="/" style="margin-left:auto">Telemetria</a>
-  <a href="/traceroutes">Traceroute</a>
+  <a href="/map">Mappa</a>
 </header>
-<div id="map"></div>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/map.js"></script>
+<div id="routes"></div>
+<script src="/static/traceroutes.js"></script>
 </body></html>

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -1,0 +1,49 @@
+let nodeNames = new Map();
+
+function nameOf(id){
+  return nodeNames.get(id) || id;
+}
+
+async function loadNodes(){
+  const res = await fetch('/api/nodes');
+  const nodes = await res.json();
+  for (const n of nodes){
+    const name = n.nickname || n.long_name || n.short_name || n.node_id;
+    nodeNames.set(n.node_id, name);
+  }
+}
+
+async function loadTraceroutes(){
+  const res = await fetch('/api/traceroutes?limit=1000');
+  const routes = await res.json();
+  const groups = new Map();
+  for (const r of routes){
+    if (!groups.has(r.src_id)) groups.set(r.src_id, []);
+    groups.get(r.src_id).push(r);
+  }
+  const container = document.getElementById('routes');
+  container.innerHTML = '';
+  for (const [src, list] of groups){
+    const sec = document.createElement('section');
+    const h = document.createElement('h3');
+    h.textContent = `${nameOf(src)} (${src})`;
+    sec.appendChild(h);
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    thead.innerHTML = '<tr><th>Destinazione</th><th>Hop</th><th>Percorso</th></tr>';
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    for (const r of list){
+      const tr = document.createElement('tr');
+      const destName = nameOf(r.dest_id);
+      const path = r.route.map(id => nameOf(id)).join(' → ');
+      tr.innerHTML = `<td>${destName} (${r.dest_id})</td><td>${r.hop_count}</td><td>${path}</td>`;
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    sec.appendChild(table);
+    container.appendChild(sec);
+  }
+}
+
+loadNodes().then(loadTraceroutes);


### PR DESCRIPTION
## Summary
- Draw traceroute paths on the map with polylines and hop markers
- Document map view for visualizing traceroute connections
- Add traceroute summary page grouping routes by source node

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b960b5bf88832396d52a472067b358