### PR TITLE
Display node short names on map markers

### DIFF
--- a/static/map.html
+++ b/static/map.html
@@ -34,6 +34,16 @@ header a{color:var(--accent);text-decoration:none}
   border:1px solid var(--bd);
   border-radius:8px;
 }
+.node-label{
+  background:var(--card-bg);
+  color:var(--accent);
+  border:1px solid var(--accent);
+  border-radius:4px;
+  padding:2px 4px;
+  font-size:12px;
+  font-weight:bold;
+  white-space:nowrap;
+}
 </style>
 </head>
 <body>

--- a/static/map.js
+++ b/static/map.js
@@ -15,9 +15,11 @@ async function loadNodes(){
   let first = true;
   for (const n of nodes){
     if (n.lat != null && n.lon != null){
-      const name = n.nickname || n.long_name || n.short_name || n.node_id;
+      const short = n.short_name || n.node_id;
+      const name = n.nickname || n.long_name || short;
 
       const m = L.marker([n.lat, n.lon]).addTo(map);
+      m.bindTooltip(short, {permanent:true, direction:'top', className:'node-label'});
       const last = n.last_seen ? new Date(n.last_seen*1000).toLocaleString() : '';
       const alt = n.alt != null ? `<br/>Alt: ${n.alt} m` : '';
       m.bindPopup(`<b>${name}</b><br/>ID: ${n.node_id}<br/>Ultimo: ${last}${alt}`);


### PR DESCRIPTION
## Summary
- Show each node's short name directly on map markers
- Add marker label styling for better visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9860a8bec8323aaa89bebcfc4fe8f