### PR TITLE
Display traceroute links on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MeshPlotter
 
-MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js.
+MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js. A map view illustrates node positions and their traceroute connections.
 
 All MQTT packets, including text messages, waypoints and other application types, are stored in the `messages` table for future use alongside the parsed telemetry and traceroute information.
 
@@ -10,4 +10,6 @@ All MQTT packets, including text messages, waypoints and other application types
 2. Install dependencies: `pip install -r requirements.txt`
 3. Start the server: `python app.py`
 4. Visit `http://localhost:8080` to view the dashboard.
+5. Visit `http://localhost:8080/map` to see nodes and traceroute links on a map. Use the "Collegamenti" checkbox to hide or show the orange route lines.
+6. Visit `http://localhost:8080/traceroutes` for a per-node traceroute summary.
 

--- a/api.py
+++ b/api.py
@@ -69,6 +69,11 @@ def map_ui():
     return FileResponse(os.path.join("static", "map.html"))
 
 
+@app.get("/traceroutes")
+def traceroutes_ui():
+    return FileResponse(os.path.join("static", "traceroutes.html"))
+
+
 @app.get("/api/nodes")
 def api_nodes():
     with DB_LOCK:

--- a/processing.py
+++ b/processing.py
@@ -461,16 +461,36 @@ def _store_metrics(node_id: str, now_s: int, data: Dict[str, Any]) -> None:
 
 def _store_traceroute(node_id: str, now_s: int, data: Dict[str, Any]) -> None:
     """Persist traceroute information if present in the message."""
-
     decoded = data.get("decoded") if isinstance(data.get("decoded"), dict) else None
-    if not (decoded and decoded.get("portnum") == "TRACEROUTE_APP"):
+    payload: Optional[Dict[str, Any]] = None
+
+    if decoded:
+        portnum = decoded.get("portnum")
+        if isinstance(portnum, int):
+            if portnum != 70:  # TRACEROUTE_APP
+                return
+        elif portnum != "TRACEROUTE_APP":
+            return
+        payload = decoded.get("payload") if isinstance(decoded.get("payload"), dict) else {}
+
+    if payload is None:
+        cand = data.get("payload") if isinstance(data.get("payload"), dict) else data
+        if not isinstance(cand.get("route"), list):
+            return
+        payload = cand
+
+    route_vals = payload.get("route") or []
+    route_hex = [r for r in (_norm_node_id(v) for v in route_vals) if r]
+    if len(route_hex) < 2:
         return
-    payload = decoded.get("payload") or {}
-    route_nums = payload.get("route") or []
-    route_hex = [format(int(n), "x") for n in route_nums]
-    src = _norm_node_id(data.get("from")) or node_id
-    dest = _norm_node_id(data.get("to"))
-    hop_count = max(len(route_hex) - 1, 0)
+
+    src = _norm_node_id(payload.get("from") or data.get("from")) or node_id
+    dest = _norm_node_id(payload.get("to") or data.get("to"))
+    hop_count = (
+        payload.get("hop_count")
+        or payload.get("hopCount")
+        or max(len(route_hex) - 1, 0)
+    )
     with DB_LOCK:
         DB.execute(
             "INSERT INTO traceroutes(ts, src_id, dest_id, route, hop_count) VALUES(?,?,?,?,?)",

--- a/static/index.html
+++ b/static/index.html
@@ -104,6 +104,7 @@ small{color:#94a3b8}
   <button id="save-nick">Salva Nickname</button>
   <button id="refresh">Aggiorna</button>
   <a href="/map">Mappa</a>
+  <a href="/traceroutes">Traceroute</a>
   <label><input type="checkbox" id="show-nick" checked/> Mostra nickname</label>
   <label style="margin-left:auto">
     <input type="checkbox" id="autoref" checked/> Auto-refresh (15s)

--- a/static/map.js
+++ b/static/map.js
@@ -6,7 +6,9 @@ L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
 
 let nodes = [];
 const routeLines = [];
+const routeMarkers = new Map();
 let focusLine = null;
+let routesVisible = true;
 
 async function loadNodes(){
   const res = await fetch('/api/nodes');
@@ -26,39 +28,74 @@ async function loadNodes(){
 }
 
 async function loadTraceroutes(){
-  const res = await fetch('/api/traceroutes');
+  // Fetch a large batch so recent traceroutes appear on the map
+  const res = await fetch('/api/traceroutes?limit=1000');
   const routes = await res.json();
   for (const r of routes){
+    // Include src and dest IDs even if the stored route only contains hops
+    const ids = [r.src_id, ...(r.route || []), r.dest_id].filter(Boolean);
     const path = [];
-    for (const id of r.route){
+    for (const id of ids){
       const n = nodes.find(nd => nd.node_id === id);
       if (n && n.lat != null && n.lon != null){
         path.push([n.lat, n.lon]);
       }
     }
     if (path.length >= 2){
-      const line = L.polyline(path, {color:'#ff6d00', weight:2}).addTo(map);
+      const line = L.polyline(path, {color:'#ff6d00', weight:2});
       line.bindTooltip(`${r.hop_count} hop${r.hop_count===1?'':'s'}`, {permanent:true});
       line.on('click', () => highlightRoute(line));
+      const markers = path.map(pt => L.circleMarker(pt, {radius:4, color:'#ff6d00'}));
       routeLines.push(line);
+      routeMarkers.set(line, markers);
+      if (routesVisible){
+        line.addTo(map);
+        markers.forEach(m => m.addTo(map));
+      }
     }
   }
 }
 
 function highlightRoute(line){
+  if (!routesVisible) return;
   if (focusLine === line){
-    routeLines.forEach(l => { if (!map.hasLayer(l)) l.addTo(map).setStyle({color:'#ff6d00', weight:2}); });
+    routeLines.forEach(l => {
+      if (!map.hasLayer(l)){
+        l.addTo(map).setStyle({color:'#ff6d00', weight:2});
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#ff6d00'}));
+      }
+    });
     focusLine = null;
   } else {
     routeLines.forEach(l => {
       if (l === line){
         l.setStyle({color:'#0ff', weight:4}).bringToFront();
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#0ff'}).bringToFront());
       } else {
         map.removeLayer(l);
+        routeMarkers.get(l).forEach(m => map.removeLayer(m));
       }
     });
     focusLine = line;
   }
 }
+
+function setRoutesVisibility(vis){
+  routesVisible = vis;
+  routeLines.forEach(l => {
+    if (vis){
+      l.addTo(map).setStyle({color:'#ff6d00', weight:2});
+      routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#ff6d00'}));
+    } else {
+      map.removeLayer(l);
+      routeMarkers.get(l).forEach(m => map.removeLayer(m));
+    }
+  });
+  if (!vis) focusLine = null;
+}
+
+document.getElementById('showRoutes').addEventListener('change', e => {
+  setRoutesVisibility(e.target.checked);
+});
 
 loadNodes().then(loadTraceroutes);

--- a/static/traceroutes.html
+++ b/static/traceroutes.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="it"><head>
-<meta charset="utf-8"/><title>Mappa Nodi</title>
+<meta charset="utf-8"/>
+<title>Traceroutes</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg"/>
 <style>
 :root{
@@ -28,22 +28,18 @@ header{
   box-shadow:0 1px 2px rgba(0,0,0,0.5);
 }
 header a{color:var(--accent);text-decoration:none}
-#map{
-  height:90vh;
-  margin:0 16px 16px;
-  border:1px solid var(--bd);
-  border-radius:8px;
-}
+section{margin:16px}
+section h3{margin:16px 0 8px}
+table{width:100%;border-collapse:collapse}
+th,td{padding:4px 8px;border-bottom:1px solid var(--bd);text-align:left}
 </style>
 </head>
 <body>
 <header>
-  <h2 style="margin:0">Mappa Nodi</h2>
+  <h2 style="margin:0">Traceroutes</h2>
   <a href="/" style="margin-left:auto">Telemetria</a>
-  <a href="/traceroutes">Traceroute</a>
-  <label style="display:flex;align-items:center;gap:4px;"><input type="checkbox" id="showRoutes" checked/> Collegamenti</label>
+  <a href="/map">Mappa</a>
 </header>
-<div id="map"></div>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/map.js"></script>
+<div id="routes"></div>
+<script src="/static/traceroutes.js"></script>
 </body></html>

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -1,0 +1,49 @@
+let nodeNames = new Map();
+
+function nameOf(id){
+  return nodeNames.get(id) || id;
+}
+
+async function loadNodes(){
+  const res = await fetch('/api/nodes');
+  const nodes = await res.json();
+  for (const n of nodes){
+    const name = n.nickname || n.long_name || n.short_name || n.node_id;
+    nodeNames.set(n.node_id, name);
+  }
+}
+
+async function loadTraceroutes(){
+  const res = await fetch('/api/traceroutes?limit=1000');
+  const routes = await res.json();
+  const groups = new Map();
+  for (const r of routes){
+    if (!groups.has(r.src_id)) groups.set(r.src_id, []);
+    groups.get(r.src_id).push(r);
+  }
+  const container = document.getElementById('routes');
+  container.innerHTML = '';
+  for (const [src, list] of groups){
+    const sec = document.createElement('section');
+    const h = document.createElement('h3');
+    h.textContent = `${nameOf(src)} (${src})`;
+    sec.appendChild(h);
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    thead.innerHTML = '<tr><th>Destinazione</th><th>Hop</th><th>Percorso</th></tr>';
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    for (const r of list){
+      const tr = document.createElement('tr');
+      const destName = nameOf(r.dest_id);
+      const path = r.route.map(id => nameOf(id)).join(' → ');
+      tr.innerHTML = `<td>${destName} (${r.dest_id})</td><td>${r.hop_count}</td><td>${path}</td>`;
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    sec.appendChild(table);
+    container.appendChild(sec);
+  }
+}
+
+loadNodes().then(loadTraceroutes);

--- a/tests/test_mqtt_processing.py
+++ b/tests/test_mqtt_processing.py
@@ -201,3 +201,22 @@ def test_store_generic_message():
     assert row[1] == 'TEXT_MESSAGE_APP'
     assert data['decoded']['payload']['text'] == 'hello'
 
+
+def test_process_traceroute_json():
+    reset_db()
+    msg = {
+        'from': 'ff01',
+        'to': 'a1b2',
+        'route': ['ff01', 'a1b2'],
+    }
+    payload = json.dumps(msg).encode()
+    app.process_mqtt_message('msh/ff01/traceroute', payload)
+    with app.DB_LOCK:
+        row = app.DB.execute(
+            'SELECT src_id, dest_id, hop_count, route FROM traceroutes'
+        ).fetchone()
+    assert row[0] == 'ff01'
+    assert row[1] == 'a1b2'
+    assert row[2] == 1
+    assert json.loads(row[3]) == ['ff01', 'a1b2']
+


### PR DESCRIPTION
## Summary
- Draw traceroute routes in orange and add a "Collegamenti" checkbox to toggle link visibility on the map
- Document the map checkbox in the Quick start guide

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b960b5bf88832396d52a472067b358