### PR TITLE
Remove nickname management

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3,9 +3,6 @@ const $nodes = document.getElementById('nodes');
 const $range = document.getElementById('range');
 const $refresh = document.getElementById('refresh');
 const $autoref = document.getElementById('autoref');
-const $nick = document.getElementById('nick');
-const $saveNick = document.getElementById('save-nick');
-const $showNick = document.getElementById('show-nick');
 
 let nodesMap = {};
 
@@ -97,7 +94,6 @@ try {
 function saveViewSettings(){
   const settings = {
     range: $range.value,
-    showNick: $showNick.checked,
     autoref: $autoref.checked,
     toggles: Object.fromEntries(Object.entries(toggles).map(([fam, el]) => [fam, el.checked])),
     nodes: Array.from($nodes.querySelectorAll('input[type=checkbox]:checked')).map(cb => cb.value)
@@ -117,10 +113,6 @@ function loadViewSettings(){
     const settings = JSON.parse(raw);
     _hasViewSettings = true;
     if (settings.range) $range.value = settings.range;
-    if ('showNick' in settings){
-      const v = settings.showNick;
-      $showNick.checked = v === true || v === 'true' || v === 1 || v === '1';
-    }
     if (typeof settings.autoref === 'boolean') $autoref.checked = settings.autoref;
     if (settings.toggles){
       for (const [fam, on] of Object.entries(settings.toggles)){
@@ -152,7 +144,6 @@ async function loadNodes(){
     const preselect = selected.length ? selected : _savedNodes;
     $nodes.innerHTML = '';
     nodesMap = {};
-    const useNick = $showNick.checked;
     for (const n of nodes){
       nodesMap[n.node_id] = n;
       const labelEl = document.createElement('label');
@@ -160,25 +151,18 @@ async function loadNodes(){
       cb.type = 'checkbox';
       cb.value = n.node_id;
       if (preselect.includes(n.node_id)) cb.checked = true;
-      cb.onchange = () => { updateNickInput(); saveViewSettings(); loadData(); };
-      let label;
-      if (useNick){
-        label = n.nickname || n.long_name || n.short_name || n.node_id;
-
-      } else {
-        const parts = [];
-        if (n.long_name) parts.push(n.long_name);
-        if (n.short_name && n.short_name !== n.long_name) parts.push(n.short_name);
-        if (!parts.length) parts.push(n.node_id);
-        label = parts.join(' / ');
-      }
+      cb.onchange = () => { saveViewSettings(); loadData(); };
+      const parts = [];
+      if (n.long_name) parts.push(n.long_name);
+      if (n.short_name && n.short_name !== n.long_name) parts.push(n.short_name);
+      if (!parts.length) parts.push(n.node_id);
+      const label = parts.join(' / ');
       labelEl.appendChild(cb);
       labelEl.append(` ${label} (${n.info_packets})`);
       labelEl.title = `${n.node_id} — info: ${n.info_packets}`;
       $nodes.appendChild(labelEl);
       $nodes.appendChild(document.createElement('br'));
     }
-    updateNickInput();
     const errEl = document.getElementById('nodes-error');
     if (errEl) errEl.remove();
   } catch (err) {
@@ -194,12 +178,6 @@ async function loadNodes(){
   }
 }
 
-function updateNickInput(){
-  const first = $nodes.querySelector('input[type=checkbox]:checked');
-  const n = first ? nodesMap[first.value] : null;
-  $nick.value = n && n.nickname ? n.nickname : '';
-}
-
 async function loadData(){
   const ids = Array.from($nodes.querySelectorAll('input[type=checkbox]:checked')).map(cb => cb.value);
   const names = ids.join(',');
@@ -207,7 +185,6 @@ async function loadData(){
   const url = new URL('/api/metrics', location.origin);
   if (names) url.searchParams.set('nodes', names);
   url.searchParams.set('since_s', since);
-  url.searchParams.set('use_nick', $showNick.checked ? '1' : '0');
   const res = await fetch(url);
   const data = await res.json();
   const series = data.series || {};
@@ -232,20 +209,7 @@ async function loadData(){
 }
 
 $refresh.onclick = () => { loadNodes(); loadData(); };
-$saveNick.onclick = async () => {
-  const first = $nodes.querySelector('input[type=checkbox]:checked');
-  const id = first ? first.value : null;
-  if (!id) return;
-  await fetch('/api/nodes/nickname', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ node_id: id, nickname: $nick.value })
-  });
-  await loadNodes();
-  await loadData();
-};
 $range.onchange = () => { saveViewSettings(); loadData(); };
-$showNick.onchange = () => { saveViewSettings(); loadNodes(); loadData(); };
 $autoref.onchange = () => {
   saveViewSettings();
   clearInterval(window._timer);

--- a/static/index.html
+++ b/static/index.html
@@ -97,15 +97,9 @@ small{color:#94a3b8}
       <option value="604800">Ultimi 7 giorni</option>
     </select>
   </label>
-  <label>
-    <small>Nickname</small><br/>
-    <input id="nick" type="text"/>
-  </label>
-  <button id="save-nick">Salva Nickname</button>
   <button id="refresh">Aggiorna</button>
   <a href="/map">Mappa</a>
   <a href="/traceroutes">Traceroute</a>
-  <label><input type="checkbox" id="show-nick" checked/> Mostra nickname</label>
   <label style="margin-left:auto">
     <input type="checkbox" id="autoref" checked/> Auto-refresh (15s)
   </label>

--- a/static/map.js
+++ b/static/map.js
@@ -15,7 +15,7 @@ async function loadNodes(){
   let first = true;
   for (const n of nodes){
     if (n.lat != null && n.lon != null){
-      const name = n.nickname || n.long_name || n.short_name || n.node_id;
+      const name = n.long_name || n.short_name || n.node_id;
 
       const m = L.marker([n.lat, n.lon]).addTo(map);
       const last = n.last_seen ? new Date(n.last_seen*1000).toLocaleString() : '';

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -8,7 +8,7 @@ async function loadNodes(){
   const res = await fetch('/api/nodes');
   const nodes = await res.json();
   for (const n of nodes){
-    const name = n.nickname || n.long_name || n.short_name || n.node_id;
+    const name = n.long_name || n.short_name || n.node_id;
     nodeNames.set(n.node_id, name);
   }
 }


### PR DESCRIPTION
## Summary
- drop nickname column and related logic
- remove nickname handling from API and UI
- fix missing Any import to avoid runtime error when serving metrics

## Testing
- `pytest` *(fails: FileNotFoundError: No such file or directory: 'mosquitto')*

------
https://chatgpt.com/codex/tasks/task_e_68b986fb26ac8323a77030e93a9b0343