### PR TITLE
Add admin SQL page for database testing

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="it"><head>
+<meta charset="utf-8"/><title>DB Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg"/>
+<style>
+body{font-family:system-ui,Segoe UI,Roboto,Ubuntu,sans-serif;margin:16px;background:#0f172a;color:#f8fafc}
+textarea{width:100%;height:200px;margin-bottom:8px;background:#1e293b;color:#f8fafc;border:1px solid #334155;border-radius:6px;padding:8px}
+button{padding:8px 12px;background:#ff6d00;color:#fff;border:none;border-radius:6px;cursor:pointer}
+pre{background:#1e293b;color:#f8fafc;padding:8px;border-radius:6px;white-space:pre-wrap}
+</style>
+</head><body>
+<h2>DB Admin</h2>
+<p>Esegui query SQL per modificare il database.</p>
+<textarea id="query" placeholder="SQL"></textarea><br/>
+<button id="run">Esegui</button>
+<pre id="out"></pre>
+<script>
+const run=document.getElementById('run');
+run.addEventListener('click',async()=>{
+  const q=document.getElementById('query').value;
+  const res=await fetch('/api/admin/sql',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query:q})});
+  const data=await res.json();
+  document.getElementById('out').textContent=JSON.stringify(data,null,2);
+});
+</script>
+</body></html>

--- a/tests/test_api_admin_sql.py
+++ b/tests/test_api_admin_sql.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import json
+
+os.environ['TP_CONFIG'] = os.path.join(os.path.dirname(__file__), 'test.config.yml')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import api  # noqa: E402
+
+
+def reset_nodes():
+    with api.DB_LOCK:
+        api.DB.execute('DELETE FROM nodes')
+        api.DB.commit()
+
+
+def test_admin_sql_can_modify_db():
+    reset_nodes()
+    api.api_admin_sql({
+        'query': 'INSERT INTO nodes(node_id, short_name) VALUES(?, ?)',
+        'params': ['n1', 'short']
+    })
+    res = api.api_admin_sql({'query': 'SELECT node_id, short_name FROM nodes'})
+    data = json.loads(res.body)
+    assert data['rows'][0]['node_id'] == 'n1'
+    assert data['rows'][0]['short_name'] == 'short'


### PR DESCRIPTION
## Summary
- expose `/admin` page for running SQL queries against the DB
- add `/api/admin/sql` endpoint to execute queries
- cover SQL interface with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b99ed8d8cc8323bf85671de747d6a4