### PR TITLE
Improve traceroute table alignment

### DIFF
--- a/static/traceroutes.html
+++ b/static/traceroutes.html
@@ -32,6 +32,8 @@ section{margin:16px}
 section h3{margin:16px 0 8px}
 table{width:100%;border-collapse:collapse}
 th,td{padding:4px 8px;border-bottom:1px solid var(--bd);text-align:left}
+th:nth-child(2),td:nth-child(2){text-align:right;width:3ch}
+th:nth-child(n+3),td:nth-child(n+3){font-family:monospace;white-space:nowrap}
 </style>
 </head>
 <body>

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -29,15 +29,34 @@ async function loadTraceroutes(){
     h.textContent = `${nameOf(src)} (${src})`;
     sec.appendChild(h);
     const table = document.createElement('table');
+    const maxHops = Math.max(...list.map(r => r.route.length));
     const thead = document.createElement('thead');
-    thead.innerHTML = '<tr><th>Destinazione</th><th>Hop</th><th>Percorso</th></tr>';
+    const headerRow = document.createElement('tr');
+    headerRow.innerHTML = '<th>Destinazione</th><th>Hop</th>';
+    for (let i = 1; i <= maxHops; i++){
+      const th = document.createElement('th');
+      th.textContent = i;
+      headerRow.appendChild(th);
+    }
+    thead.appendChild(headerRow);
     table.appendChild(thead);
     const tbody = document.createElement('tbody');
     for (const r of list){
       const tr = document.createElement('tr');
       const destName = nameOf(r.dest_id);
-      const path = r.route.map(id => nameOf(id)).join(' → ');
-      tr.innerHTML = `<td>${destName} (${r.dest_id})</td><td>${r.hop_count}</td><td>${path}</td>`;
+      const destCell = document.createElement('td');
+      destCell.textContent = `${destName} (${r.dest_id})`;
+      tr.appendChild(destCell);
+      const hopCell = document.createElement('td');
+      hopCell.textContent = r.hop_count;
+      tr.appendChild(hopCell);
+      for (let i = 0; i < maxHops; i++){
+        const td = document.createElement('td');
+        if (i < r.route.length){
+          td.textContent = nameOf(r.route[i]);
+        }
+        tr.appendChild(td);
+      }
       tbody.appendChild(tr);
     }
     table.appendChild(tbody);


### PR DESCRIPTION
## Summary
- display each hop of traceroute paths in its own column
- apply monospace styling to hop columns for consistent layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b995f0f8e88323a6d8f4c2bfe81589