### PR TITLE
Add traceroute info popup with radio metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MeshPlotter
 
-MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js.
+MeshPlotter collects telemetry data from Meshtastic MQTT topics, stores them in SQLite and provides a simple web dashboard built with FastAPI and Chart.js. A map view illustrates node positions and their traceroute connections.
 
 All MQTT packets, including text messages, waypoints and other application types, are stored in the `messages` table for future use alongside the parsed telemetry and traceroute information.
 
@@ -10,4 +10,6 @@ All MQTT packets, including text messages, waypoints and other application types
 2. Install dependencies: `pip install -r requirements.txt`
 3. Start the server: `python app.py`
 4. Visit `http://localhost:8080` to view the dashboard.
+5. Visit `http://localhost:8080/map` to see nodes and traceroute links on a map. Use the "Collegamenti" checkbox to hide or show the route lines and "Nomi nodi" to toggle node labels. Link colours range from green (0 hop) to red (7+ hops). Click a traceroute line to view sender, destination, timestamp, distance and radio metrics.
+6. Visit `http://localhost:8080/traceroutes` for a per-node traceroute summary.
 

--- a/api.py
+++ b/api.py
@@ -69,6 +69,11 @@ def map_ui():
     return FileResponse(os.path.join("static", "map.html"))
 
 
+@app.get("/traceroutes")
+def traceroutes_ui():
+    return FileResponse(os.path.join("static", "traceroutes.html"))
+
+
 @app.get("/api/nodes")
 def api_nodes():
     with DB_LOCK:
@@ -109,17 +114,21 @@ def api_nodes():
 def api_traceroutes(limit: int = Query(default=100, ge=1, le=1000)):
     with DB_LOCK:
         cur = DB.execute(
-            "SELECT ts, src_id, dest_id, route, hop_count FROM traceroutes ORDER BY id DESC LIMIT ?",
+            "SELECT ts, src_id, dest_id, route, hop_count, radio FROM traceroutes ORDER BY id DESC LIMIT ?",
             (limit,),
         )
         rows = cur.fetchall()
     out = []
-    for ts, src, dest, route_json, hop in rows:
+    for ts, src, dest, route_json, hop, radio_json in rows:
         try:
             route = json.loads(route_json) if route_json else []
         except Exception:
             route = []
-        out.append({"ts": ts, "src_id": src, "dest_id": dest, "route": route, "hop_count": hop})
+        try:
+            radio = json.loads(radio_json) if radio_json else None
+        except Exception:
+            radio = None
+        out.append({"ts": ts, "src_id": src, "dest_id": dest, "route": route, "hop_count": hop, "radio": radio})
     return JSONResponse(out)
 
 

--- a/database.py
+++ b/database.py
@@ -93,10 +93,15 @@ def migrate() -> None:
               src_id TEXT,
               dest_id TEXT,
               route TEXT,
-              hop_count INTEGER
+              hop_count INTEGER,
+              radio TEXT
             )
             """,
         )
+
+        tcols = [c[1] for c in DB.execute("PRAGMA table_info(traceroutes)").fetchall()]
+        if "radio" not in tcols:
+            DB.execute("ALTER TABLE traceroutes ADD COLUMN radio TEXT")
 
         DB.execute(
             """

--- a/processing.py
+++ b/processing.py
@@ -461,20 +461,50 @@ def _store_metrics(node_id: str, now_s: int, data: Dict[str, Any]) -> None:
 
 def _store_traceroute(node_id: str, now_s: int, data: Dict[str, Any]) -> None:
     """Persist traceroute information if present in the message."""
-
     decoded = data.get("decoded") if isinstance(data.get("decoded"), dict) else None
-    if not (decoded and decoded.get("portnum") == "TRACEROUTE_APP"):
+    payload: Optional[Dict[str, Any]] = None
+
+    if decoded:
+        portnum = decoded.get("portnum")
+        if isinstance(portnum, int):
+            if portnum != 70:  # TRACEROUTE_APP
+                return
+        elif portnum != "TRACEROUTE_APP":
+            return
+        payload = decoded.get("payload") if isinstance(decoded.get("payload"), dict) else {}
+
+    if payload is None:
+        cand = data.get("payload") if isinstance(data.get("payload"), dict) else data
+        if not isinstance(cand.get("route"), list):
+            return
+        payload = cand
+
+    route_vals = payload.get("route") or []
+    route_hex = [r for r in (_norm_node_id(v) for v in route_vals) if r]
+    if len(route_hex) < 2:
         return
-    payload = decoded.get("payload") or {}
-    route_nums = payload.get("route") or []
-    route_hex = [format(int(n), "x") for n in route_nums]
-    src = _norm_node_id(data.get("from")) or node_id
-    dest = _norm_node_id(data.get("to"))
-    hop_count = max(len(route_hex) - 1, 0)
+
+    src = _norm_node_id(payload.get("from") or data.get("from")) or node_id
+    dest = _norm_node_id(payload.get("to") or data.get("to"))
+    hop_count = (
+        payload.get("hop_count")
+        or payload.get("hopCount")
+        or max(len(route_hex) - 1, 0)
+    )
+
+    radio_info: Dict[str, Any] = {}
+    for k in ("snr", "SNR", "rssi", "RSSI"):
+        if k in payload:
+            radio_info[k.lower()] = payload[k]
+    if isinstance(payload.get("radio"), dict):
+        for k, v in payload["radio"].items():
+            radio_info[str(k)] = v
+    radio_json = json.dumps(radio_info) if radio_info else None
+
     with DB_LOCK:
         DB.execute(
-            "INSERT INTO traceroutes(ts, src_id, dest_id, route, hop_count) VALUES(?,?,?,?,?)",
-            (now_s, src, dest, json.dumps(route_hex), hop_count),
+            "INSERT INTO traceroutes(ts, src_id, dest_id, route, hop_count, radio) VALUES(?,?,?,?,?,?)",
+            (now_s, src, dest, json.dumps(route_hex), hop_count, radio_json),
         )
         DB.commit()
         

--- a/static/index.html
+++ b/static/index.html
@@ -104,6 +104,7 @@ small{color:#94a3b8}
   <button id="save-nick">Salva Nickname</button>
   <button id="refresh">Aggiorna</button>
   <a href="/map">Mappa</a>
+  <a href="/traceroutes">Traceroute</a>
   <label><input type="checkbox" id="show-nick" checked/> Mostra nickname</label>
   <label style="margin-left:auto">
     <input type="checkbox" id="autoref" checked/> Auto-refresh (15s)

--- a/static/map.html
+++ b/static/map.html
@@ -34,12 +34,43 @@ header a{color:var(--accent);text-decoration:none}
   border:1px solid var(--bd);
   border-radius:8px;
 }
+.node-label{
+  background:var(--accent);
+  color:var(--bg);
+  border-radius:50%;
+  width:24px;
+  height:24px;
+  line-height:24px;
+  text-align:center;
+  font-weight:600;
+}
+.hop-legend{
+  background:var(--card-bg);
+  padding:4px;
+  line-height:14px;
+  color:var(--text);
+}
+.hop-legend span{
+  display:inline-block;
+  width:12px;
+  height:12px;
+  margin-right:4px;
+}
 </style>
 </head>
 <body>
 <header>
   <h2 style="margin:0">Mappa Nodi</h2>
   <a href="/" style="margin-left:auto">Telemetria</a>
+  <a href="/traceroutes">Traceroute</a>
+  <label style="display:flex;align-items:center;gap:4px;">
+    <input type="checkbox" id="showRoutes" checked/>
+    Collegamenti
+  </label>
+  <label style="display:flex;align-items:center;gap:4px;">
+    <input type="checkbox" id="showNames"/>
+    Nomi nodi
+  </label>
 </header>
 <div id="map"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>

--- a/static/map.js
+++ b/static/map.js
@@ -1,64 +1,223 @@
-const map = L.map('map').setView([0,0], 2);
-L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-  maxZoom: 19,
-  attribution: '&copy; OpenStreetMap contributors &copy; CARTO'
-}).addTo(map);
-
+let map;
 let nodes = [];
+const nodeMarkers = new Map();
+const nodePositions = new Map();
 const routeLines = [];
+const routeMarkers = new Map();
 let focusLine = null;
+let routesVisible = true;
+let showNames = false;
+const hopColors = ['#00ff00','#7fff00','#bfff00','#ffff00','#ffbf00','#ff8000','#ff4000','#ff0000'];
+
+function haversine(lat1, lon1, lat2, lon2){
+  const R = 6371;
+  const toRad = d => d * Math.PI / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat/2)**2 + Math.cos(toRad(lat1))*Math.cos(toRad(lat2))*Math.sin(dLon/2)**2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
 
 async function loadNodes(){
-  const res = await fetch('/api/nodes');
-  nodes = await res.json();
-  let first = true;
-  for (const n of nodes){
+  let fetched = [];
+  try{
+    const res = await fetch('/api/nodes');
+    fetched = await res.json();
+  }catch{
+    return;
+  }
+  let first = nodes.length === 0;
+  for (const n of fetched){
     if (n.lat != null && n.lon != null){
-      const name = n.nickname || n.long_name || n.short_name || n.node_id;
-
-      const m = L.marker([n.lat, n.lon]).addTo(map);
-      const last = n.last_seen ? new Date(n.last_seen*1000).toLocaleString() : '';
-      const alt = n.alt != null ? `<br/>Alt: ${n.alt} m` : '';
-      m.bindPopup(`<b>${name}</b><br/>ID: ${n.node_id}<br/>Ultimo: ${last}${alt}`);
-      if (first){ map.setView([n.lat, n.lon], 13); first = false; }
+      const pos = [n.lat, n.lon];
+      const prev = nodePositions.get(n.node_id);
+      if (prev){
+        if (prev[0] !== pos[0] || prev[1] !== pos[1]){
+          removeNodeRoutes(n.node_id);
+          const mk = nodeMarkers.get(n.node_id);
+          if (mk) mk.marker.setLatLng(pos);
+        }
+      }else{
+        const name = n.nickname || n.long_name || n.short_name || n.node_id;
+        const icon = L.divIcon({className:'node-label', html:showNames && n.short_name ? n.short_name : '', iconSize:[24,24]});
+        const m = L.marker(pos,{icon}).addTo(map);
+        const last = n.last_seen ? new Date(n.last_seen*1000).toLocaleString() : '';
+        const alt = n.alt != null ? `<br/>Alt: ${n.alt} m` : '';
+        m.bindPopup(`<b>${name}</b><br/>ID: ${n.node_id}<br/>Ultimo: ${last}${alt}`);
+        nodeMarkers.set(n.node_id,{marker:m,short:n.short_name||''});
+        if (first){ map.setView(pos,13); first=false; }
+      }
+      nodePositions.set(n.node_id,pos);
     }
   }
+  nodes = fetched;
+}
+
+function clearRoutes(){
+  routeLines.forEach(l => {
+    map.removeLayer(l);
+    routeMarkers.get(l).forEach(m => map.removeLayer(m));
+  });
+  routeLines.length = 0;
+  routeMarkers.clear();
+  focusLine = null;
 }
 
 async function loadTraceroutes(){
-  const res = await fetch('/api/traceroutes');
-  const routes = await res.json();
+  clearRoutes();
+  let routes = [];
+  try{
+    // Fetch a large batch so recent traceroutes appear on the map
+    const res = await fetch('/api/traceroutes?limit=1000');
+    routes = await res.json();
+  }catch{
+    routes = [];
+  }
   for (const r of routes){
+    // Include src and dest IDs even if the stored route only contains hops
+    const ids = [r.src_id, ...(r.route || []), r.dest_id].filter(Boolean);
     const path = [];
-    for (const id of r.route){
+    for (const id of ids){
       const n = nodes.find(nd => nd.node_id === id);
       if (n && n.lat != null && n.lon != null){
         path.push([n.lat, n.lon]);
       }
     }
     if (path.length >= 2){
-      const line = L.polyline(path, {color:'#ff6d00', weight:2}).addTo(map);
-      line.bindTooltip(`${r.hop_count} hop${r.hop_count===1?'':'s'}`, {permanent:true});
-      line.on('click', () => highlightRoute(line));
+      const color = hopColors[Math.min(r.hop_count, hopColors.length-1)];
+      const line = L.polyline(path, {color, weight:2});
+      line.bindTooltip(`${r.hop_count} hop${r.hop_count===1?'':'s'}`);
+      const srcNode = nodes.find(nd => nd.node_id === r.src_id) || {};
+      const destNode = nodes.find(nd => nd.node_id === r.dest_id) || {};
+      const srcName = srcNode.nickname || srcNode.long_name || srcNode.short_name || r.src_id;
+      const destName = destNode.nickname || destNode.long_name || destNode.short_name || r.dest_id;
+      let distance = null;
+      if (srcNode.lat != null && srcNode.lon != null && destNode.lat != null && destNode.lon != null){
+        distance = haversine(srcNode.lat, srcNode.lon, destNode.lat, destNode.lon);
+      }
+      line.info = {srcName, destName, ts:r.ts, distance, radio:r.radio};
+      line.on('click', e => {highlightRoute(line); if (focusLine === line) showRouteInfo(line, e.latlng);});
+      line.nodeIds = ids;
+      line.defaultColor = color;
+      const markers = path.map(pt => L.circleMarker(pt, {radius:4, color}));
       routeLines.push(line);
+      routeMarkers.set(line, markers);
+      if (routesVisible){
+        line.addTo(map);
+        markers.forEach(m => m.addTo(map));
+      }
     }
   }
 }
 
 function highlightRoute(line){
+  if (!routesVisible) return;
   if (focusLine === line){
-    routeLines.forEach(l => { if (!map.hasLayer(l)) l.addTo(map).setStyle({color:'#ff6d00', weight:2}); });
+    routeLines.forEach(l => {
+      if (!map.hasLayer(l)){
+        l.addTo(map).setStyle({color:l.defaultColor, weight:2});
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:l.defaultColor}));
+      }
+    });
     focusLine = null;
+    map.closePopup();
   } else {
     routeLines.forEach(l => {
       if (l === line){
         l.setStyle({color:'#0ff', weight:4}).bringToFront();
+        routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:'#0ff'}).bringToFront());
       } else {
         map.removeLayer(l);
+        routeMarkers.get(l).forEach(m => map.removeLayer(m));
       }
     });
     focusLine = line;
   }
 }
 
-loadNodes().then(loadTraceroutes);
+function showRouteInfo(line, latlng){
+  const info = line.info || {};
+  const time = info.ts ? new Date(info.ts*1000).toLocaleString() : '';
+  const dist = info.distance != null ? info.distance.toFixed(2) + ' km' : 'N/D';
+  let radio = 'N/D';
+  if (info.radio){
+    radio = Object.entries(info.radio).map(([k,v]) => `${k}: ${v}`).join('<br/>');
+  }
+  const html = `<b>${info.srcName||''}</b> → <b>${info.destName||''}</b><br/>${time}<br/>Distanza: ${dist}<br/>${radio}`;
+  L.popup().setLatLng(latlng).setContent(html).openOn(map);
+}
+
+function setRoutesVisibility(vis){
+  routesVisible = vis;
+  routeLines.forEach(l => {
+    if (vis){
+      l.addTo(map).setStyle({color:l.defaultColor, weight:2});
+      routeMarkers.get(l).forEach(m => m.addTo(map).setStyle({color:l.defaultColor}));
+    } else {
+      map.removeLayer(l);
+      routeMarkers.get(l).forEach(m => map.removeLayer(m));
+    }
+  });
+  if (!vis) focusLine = null;
+}
+
+function setNamesVisibility(vis){
+  showNames = vis;
+  nodeMarkers.forEach(v => {
+    const html = vis ? v.short : '';
+    v.marker.setIcon(L.divIcon({className:'node-label', html, iconSize:[24,24]}));
+  });
+}
+
+function removeNodeRoutes(nodeId){
+  routeLines.slice().forEach(l => {
+    if (l.nodeIds && l.nodeIds.includes(nodeId)){
+      map.removeLayer(l);
+      routeMarkers.get(l).forEach(m => map.removeLayer(m));
+      routeMarkers.delete(l);
+      const idx = routeLines.indexOf(l);
+      if (idx >= 0) routeLines.splice(idx,1);
+      if (focusLine === l) focusLine = null;
+    }
+  });
+}
+
+function addHopLegend(){
+  const legend = L.control({position:'bottomleft'});
+  legend.onAdd = function(){
+    const div = L.DomUtil.create('div','hop-legend');
+    hopColors.forEach((c,i)=>{
+      div.innerHTML += `<span style="background:${c}"></span>${i}<br/>`;
+    });
+    return div;
+  };
+  legend.addTo(map);
+}
+
+function init(){
+  map = L.map('map').setView([0,0], 2);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  document.getElementById('showRoutes').addEventListener('change', e => {
+    setRoutesVisibility(e.target.checked);
+  });
+  document.getElementById('showNames').addEventListener('change', e => {
+    setNamesVisibility(e.target.checked);
+  });
+
+  addHopLegend();
+}
+
+async function refresh(){
+  await loadNodes();
+  await loadTraceroutes();
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  init();
+  refresh();
+  setInterval(refresh, 10000);
+});

--- a/static/traceroutes.html
+++ b/static/traceroutes.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="it"><head>
+<meta charset="utf-8"/>
+<title>Traceroutes</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg"/>
+<style>
+:root{
+  --bd:#334155;
+  --bg:#0f172a;
+  --card-bg:#1e293b;
+  --accent:#ff6d00;
+  --text:#f8fafc;
+}
+body{
+  margin:0;
+  font-family:system-ui,Segoe UI,Roboto,Ubuntu,sans-serif;
+  background:var(--bg);
+  color:var(--text);
+}
+header{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  padding:12px 16px;
+  background:var(--card-bg);
+  color:var(--text);
+  box-shadow:0 1px 2px rgba(0,0,0,0.5);
+}
+header a{color:var(--accent);text-decoration:none}
+section{margin:16px}
+section h3{margin:16px 0 8px}
+table{width:100%;border-collapse:collapse}
+th,td{padding:4px 8px;border-bottom:1px solid var(--bd);text-align:left}
+</style>
+</head>
+<body>
+<header>
+  <h2 style="margin:0">Traceroutes</h2>
+  <a href="/" style="margin-left:auto">Telemetria</a>
+  <a href="/map">Mappa</a>
+</header>
+<div id="routes"></div>
+<script src="/static/traceroutes.js"></script>
+</body></html>

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -1,0 +1,63 @@
+let nodeNames = new Map();
+
+function nameOf(id){
+  return nodeNames.get(id) || id;
+}
+
+async function loadNodes(){
+  try{
+    const res = await fetch('/api/nodes');
+    const nodes = await res.json();
+    for (const n of nodes){
+      const name = n.nickname || n.long_name || n.short_name || n.node_id;
+      nodeNames.set(n.node_id, name);
+    }
+  }catch{
+    // Ignore network or parse errors; IDs will be shown as-is
+  }
+}
+
+async function loadTraceroutes(){
+  let routes = [];
+  try{
+    const res = await fetch('/api/traceroutes?limit=1000');
+    routes = await res.json();
+  }catch{
+    routes = [];
+  }
+  const groups = new Map();
+  for (const r of routes){
+    if (!groups.has(r.src_id)) groups.set(r.src_id, []);
+    groups.get(r.src_id).push(r);
+  }
+  const container = document.getElementById('routes');
+  container.innerHTML = '';
+  for (const [src, list] of groups){
+    const sec = document.createElement('section');
+    const h = document.createElement('h3');
+    h.textContent = `${nameOf(src)} (${src})`;
+    sec.appendChild(h);
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    thead.innerHTML = '<tr><th>Destinazione</th><th>Hop</th><th>Percorso</th></tr>';
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    for (const r of list){
+      const tr = document.createElement('tr');
+      const destName = nameOf(r.dest_id);
+      const ids = [r.src_id, ...(r.route || []), r.dest_id].filter(Boolean);
+      const path = ids.map(id => nameOf(id)).join(' → ');
+      tr.innerHTML = `<td>${destName} (${r.dest_id})</td><td>${r.hop_count}</td><td>${path}</td>`;
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    sec.appendChild(table);
+    container.appendChild(sec);
+  }
+}
+
+async function init(){
+  await loadNodes();
+  await loadTraceroutes();
+}
+init();

--- a/tests/test_mqtt_processing.py
+++ b/tests/test_mqtt_processing.py
@@ -201,3 +201,27 @@ def test_store_generic_message():
     assert row[1] == 'TEXT_MESSAGE_APP'
     assert data['decoded']['payload']['text'] == 'hello'
 
+
+def test_process_traceroute_json():
+    reset_db()
+    msg = {
+        'from': 'ff01',
+        'to': 'a1b2',
+        'route': ['ff01', 'a1b2'],
+        'snr': 7.5,
+        'rssi': -120,
+    }
+    payload = json.dumps(msg).encode()
+    app.process_mqtt_message('msh/ff01/traceroute', payload)
+    with app.DB_LOCK:
+        row = app.DB.execute(
+            'SELECT src_id, dest_id, hop_count, route, radio FROM traceroutes'
+        ).fetchone()
+    assert row[0] == 'ff01'
+    assert row[1] == 'a1b2'
+    assert row[2] == 1
+    assert json.loads(row[3]) == ['ff01', 'a1b2']
+    radio = json.loads(row[4])
+    assert radio['snr'] == 7.5
+    assert radio['rssi'] == -120
+


### PR DESCRIPTION
## Summary
- Store optional radio data with traceroutes and expose it via the API
- Show sender, destination, timestamp, distance and radio metrics when clicking a map route
- Refresh traceroute links every 10s and clear old ones to keep the map accurate
- Fix malformed checkbox markup so the map renders correctly
- Ensure traceroute summary lists always display, even if route data or node fetches fail

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b960b5bf88832396d52a472067b358