### PR TITLE
Aggiungi pagina di setup per centrare la mappa

### DIFF
--- a/api.py
+++ b/api.py
@@ -79,6 +79,11 @@ def admin_ui():
     return FileResponse(os.path.join("static", "admin.html"))
 
 
+@app.get("/setup")
+def setup_ui():
+    return FileResponse(os.path.join("static", "setup.html"))
+
+
 @app.get("/api/nodes")
 def api_nodes():
     with DB_LOCK:
@@ -126,7 +131,12 @@ def api_traceroutes(limit: int = Query(default=100, ge=1, le=1000)):
         )
         rows = cur.fetchall()
     out = []
+    seen = set()
     for ts, src, dest, route_json, hop, radio_json in rows:
+        key = (src, dest, route_json or "")
+        if key in seen:
+            continue
+        seen.add(key)
         try:
             route = json.loads(route_json) if route_json else []
         except Exception:

--- a/static/index.html
+++ b/static/index.html
@@ -105,6 +105,7 @@ small{color:#94a3b8}
   <button id="refresh">Aggiorna</button>
   <a href="/map">Mappa</a>
   <a href="/traceroutes">Traceroute</a>
+  <a href="/setup">Setup</a>
   <label><input type="checkbox" id="show-nick" checked/> Mostra nickname</label>
   <label style="margin-left:auto">
     <input type="checkbox" id="autoref" checked/> Auto-refresh (15s)

--- a/static/map.html
+++ b/static/map.html
@@ -63,6 +63,7 @@ header a{color:var(--accent);text-decoration:none}
   <h2 style="margin:0">Mappa Nodi</h2>
   <a href="/" style="margin-left:auto">Telemetria</a>
   <a href="/traceroutes">Traceroute</a>
+  <a href="/setup">Setup</a>
 
   <label style="display:flex;align-items:center;gap:4px;">
     <input type="checkbox" id="showRoutes" checked/>

--- a/static/map.js
+++ b/static/map.js
@@ -8,6 +8,7 @@ let focusLine = null;
 let routesVisible = true;
 let showNames = false;
 const hopColors = ['#00ff00','#7fff00','#bfff00','#ffff00','#ffbf00','#ff8000','#ff4000','#ff0000'];
+let centerNodeId = localStorage.getItem('centerNodeId');
 
 
 function haversine(lat1, lon1, lat2, lon2){
@@ -29,6 +30,13 @@ async function loadNodes(){
     return;
   }
   let first = nodes.length === 0;
+  if (first && centerNodeId){
+    const cn = fetched.find(n => n.node_id === centerNodeId && n.lat != null && n.lon != null);
+    if (cn){
+      map.setView([cn.lat, cn.lon],13);
+      first = false;
+    }
+  }
   for (const n of fetched){
     if (n.lat != null && n.lon != null){
       const pos = [n.lat, n.lon];
@@ -47,12 +55,16 @@ async function loadNodes(){
         const alt = n.alt != null ? `<br/>Alt: ${n.alt} m` : '';
         m.bindPopup(`<b>${name}</b><br/>ID: ${n.node_id}<br/>Ultimo: ${last}${alt}`);
         nodeMarkers.set(n.node_id,{marker:m,short:n.short_name||''});
-        if (first){ map.setView(pos,13); first=false; }
+        if (first && !centerNodeId){ map.setView(pos,13); first=false; }
       }
       nodePositions.set(n.node_id,pos);
     }
   }
   nodes = fetched;
+  if (centerNodeId){
+    const cn = nodes.find(n => n.node_id === centerNodeId && n.lat != null && n.lon != null);
+    if (cn) map.setView([cn.lat, cn.lon],13);
+  }
 
 }
 

--- a/static/setup.html
+++ b/static/setup.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="it"><head>
-<meta charset="utf-8"/>
-<title>Traceroutes</title>
+<meta charset="utf-8"/><title>Setup</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg"/>
 <style>
@@ -28,23 +27,38 @@ header{
   box-shadow:0 1px 2px rgba(0,0,0,0.5);
 }
 header a{color:var(--accent);text-decoration:none}
-section{margin:16px}
-section h3{margin:16px 0 8px}
-table{width:100%;border-collapse:collapse}
-th,td{padding:4px 8px;border-bottom:1px solid var(--bd);text-align:left}
-
-th:nth-child(2),td:nth-child(2){text-align:right;width:3ch}
-th:nth-child(n+3),td:nth-child(n+3){font-family:monospace;white-space:nowrap}
+section{
+  margin:16px;
+}
+select,button{
+  padding:6px;
+  border:1px solid var(--bd);
+  border-radius:6px;
+  background:var(--card-bg);
+  color:var(--text);
+}
+button{
+  background:var(--accent);
+  color:#fff;
+  border:none;
+  cursor:pointer;
+}
+button:hover{background:#e05500}
 </style>
-
 </head>
 <body>
 <header>
-  <h2 style="margin:0">Traceroutes</h2>
+  <h2 style="margin:0">Setup</h2>
   <a href="/" style="margin-left:auto">Telemetria</a>
   <a href="/map">Mappa</a>
-  <a href="/setup">Setup</a>
+  <a href="/traceroutes">Traceroute</a>
 </header>
-<div id="routes"></div>
-<script src="/static/traceroutes.js"></script>
+<section>
+  <label>
+    Nodo centro mappa<br/>
+    <select id="centerNode" style="min-width:260px"></select>
+  </label>
+  <button id="save" style="margin-left:8px">Salva</button>
+</section>
+<script src="/static/setup.js"></script>
 </body></html>

--- a/static/setup.js
+++ b/static/setup.js
@@ -1,0 +1,33 @@
+async function loadNodes(){
+  let nodes=[];
+  try{
+    const res=await fetch('/api/nodes');
+    nodes=await res.json();
+  }catch{
+    nodes=[];
+  }
+  const sel=document.getElementById('centerNode');
+  sel.innerHTML='';
+  const optNone=document.createElement('option');
+  optNone.value='';
+  optNone.textContent='-- Nessuno --';
+  sel.appendChild(optNone);
+  const current=localStorage.getItem('centerNodeId')||'';
+  for(const n of nodes){
+    if(n.lat==null||n.lon==null) continue;
+    const opt=document.createElement('option');
+    opt.value=n.node_id;
+    opt.textContent=n.display_name||n.node_id;
+    if(n.node_id===current) opt.selected=true;
+    sel.appendChild(opt);
+  }
+}
+
+document.getElementById('save').addEventListener('click',()=>{
+  const id=document.getElementById('centerNode').value;
+  if(id) localStorage.setItem('centerNodeId',id);
+  else localStorage.removeItem('centerNodeId');
+  alert('Salvato');
+});
+
+window.addEventListener('DOMContentLoaded',loadNodes);


### PR DESCRIPTION
## Summary
- Introduce `/setup` page with a dropdown to choose the node used to center the map.
- Persist selection in local storage and use it on the map; update UI links.
- Deduplicate traceroute results in API to avoid duplicate entries.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a2d159bc8323b12a82d349fd6f6a