### PR TITLE
Fix traceroute UI rendering

### DIFF
--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -43,22 +43,22 @@ async function loadTraceroutes(){
     const tbody = document.createElement('tbody');
     for (const r of list){
       const tr = document.createElement('tr');
-
-      const destCell = document.createElement('td');
-      destCell.textContent = `${nameOf(r.dest_id)} (${r.dest_id})`;
-
       const destName = nameOf(r.dest_id);
       const destCell = document.createElement('td');
       destCell.textContent = `${destName} (${r.dest_id})`;
-
       tr.appendChild(destCell);
+
       const hopCell = document.createElement('td');
       hopCell.textContent = r.hop_count;
       tr.appendChild(hopCell);
 
-      const pathCell = document.createElement('td');
-      pathCell.textContent = r.route.map(id => nameOf(id)).join(' → ');
-      tr.appendChild(pathCell);
+      for (let i = 0; i < maxHops; i++){
+        const stepCell = document.createElement('td');
+        if (i < r.route.length){
+          stepCell.textContent = nameOf(r.route[i]);
+        }
+        tr.appendChild(stepCell);
+      }
 
       tbody.appendChild(tr);
     }


### PR DESCRIPTION
## Summary
- remove duplicate variable definition that prevented traceroute page from loading
- render hop-by-hop path in traceroute table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa6e44e08323816c96afcd8ac6ba