### PR TITLE
Add admin action to delete empty nodes

### DIFF
--- a/api.py
+++ b/api.py
@@ -188,6 +188,28 @@ def api_admin_delete_node(node_id: str):
     return JSONResponse({"status": "ok"})
 
 
+@app.delete("/api/admin/nodes/empty")
+def api_admin_delete_empty_nodes():
+    with DB_LOCK:
+        before = DB.total_changes
+        DB.execute(
+            """
+            DELETE FROM nodes
+            WHERE short_name IS NULL
+              AND long_name IS NULL
+              AND nickname IS NULL
+              AND lat IS NULL
+              AND lon IS NULL
+              AND alt IS NULL
+              AND (last_seen IS NULL OR last_seen = 0)
+              AND (info_packets IS NULL OR info_packets = 0)
+            """
+        )
+        DB.commit()
+        deleted = DB.total_changes - before
+    return JSONResponse({"deleted": deleted})
+
+
 @app.post("/api/admin/sql")
 def api_admin_sql(payload: Dict[str, Any] = Body(...)):
     query = payload.get("query")

--- a/static/admin.html
+++ b/static/admin.html
@@ -13,6 +13,7 @@ button.delete{background:#dc2626}
 </style>
 </head><body>
 <h2>Nodes Admin</h2>
+<button id="delete-empty">Delete empty nodes</button>
 <table>
   <thead><tr><th>ID</th><th>Short</th><th>Long</th><th>Nickname</th><th>Lat</th><th>Lon</th><th>Alt</th><th></th></tr></thead>
   <tbody id="nodes-body"></tbody>
@@ -22,6 +23,7 @@ async function load(){
   const res=await fetch('/api/nodes');
   const data=await res.json();
   const tbody=document.getElementById('nodes-body');
+  tbody.innerHTML='';
   data.forEach(n=>{
     const tr=document.createElement('tr');
     tr.innerHTML=`
@@ -53,5 +55,10 @@ async function load(){
   });
 }
 document.addEventListener('DOMContentLoaded',load);
+document.getElementById('delete-empty').addEventListener('click',async()=>{
+  if(!confirm('Delete nodes without info?')) return;
+  await fetch('/api/admin/nodes/empty',{method:'DELETE'});
+  await load();
+});
 </script>
 </body></html>

--- a/tests/test_api_admin_nodes.py
+++ b/tests/test_api_admin_nodes.py
@@ -38,3 +38,19 @@ def test_admin_can_delete_nodes():
     with api.DB_LOCK:
         cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n1',))
         assert cur.fetchone()[0] == 0
+
+
+def test_admin_can_prune_empty_nodes():
+    reset_nodes()
+    with api.DB_LOCK:
+        api.DB.execute('INSERT INTO nodes(node_id, short_name) VALUES(?, ?)', ('n1', 'info'))
+        api.DB.execute('INSERT INTO nodes(node_id) VALUES(?)', ('n2',))
+        api.DB.commit()
+    res = api.api_admin_delete_empty_nodes()
+    data = json.loads(res.body)
+    assert data['deleted'] == 1
+    with api.DB_LOCK:
+        cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n1',))
+        assert cur.fetchone()[0] == 1
+        cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n2',))
+        assert cur.fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- allow administrators to prune nodes with no saved data
- add button in admin UI to trigger cleanup
- cover cleanup logic with a unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2d972c883239d3e44fd32144763