### PR TITLE
Add admin action to delete empty nodes

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -13,15 +13,17 @@ button.delete{background:#dc2626}
 </style>
 </head><body>
 <h2>Nodes Admin</h2>
+<button id="delete-empty">Delete empty nodes</button>
 <table>
   <thead><tr><th>ID</th><th>Short</th><th>Long</th><th>Nickname</th><th>Lat</th><th>Lon</th><th>Alt</th><th></th></tr></thead>
   <tbody id="nodes-body"></tbody>
 </table>
 <script>
 async function load(){
-  const res=await fetch('/api/nodes');
+  const res=await fetch('/api/nodes',{cache:'no-store'});
   const data=await res.json();
   const tbody=document.getElementById('nodes-body');
+  tbody.innerHTML='';
   data.forEach(n=>{
     const tr=document.createElement('tr');
     tr.innerHTML=`
@@ -53,5 +55,17 @@ async function load(){
   });
 }
 document.addEventListener('DOMContentLoaded',load);
+document.getElementById('delete-empty').addEventListener('click',async()=>{
+  if(!confirm('Delete nodes without info?')) return;
+  try{
+    const res=await fetch('/api/admin/nodes/empty',{method:'DELETE'});
+    if(!res.ok) throw new Error(await res.text());
+    const info=await res.json();
+    alert(`Deleted ${info.deleted} nodes`);
+    await load();
+  }catch(e){
+    alert('Deletion failed: '+e);
+  }
+});
 </script>
 </body></html>

--- a/tests/test_api_admin_nodes.py
+++ b/tests/test_api_admin_nodes.py
@@ -38,3 +38,40 @@ def test_admin_can_delete_nodes():
     with api.DB_LOCK:
         cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n1',))
         assert cur.fetchone()[0] == 0
+
+
+def test_admin_can_prune_empty_nodes():
+    reset_nodes()
+    with api.DB_LOCK:
+        api.DB.execute('INSERT INTO nodes(node_id, short_name) VALUES(?, ?)', ('n1', 'info'))
+        api.DB.execute('INSERT INTO nodes(node_id) VALUES(?)', ('n2',))
+        api.DB.execute('INSERT INTO nodes(node_id, last_seen, info_packets) VALUES(?, ?, ?)', ('n3', 123, 4))
+        api.DB.execute('INSERT INTO nodes(node_id, short_name, long_name, nickname) VALUES(?, ?, ?, ?)', ('n4', '', '  ', ''))
+        api.DB.execute('INSERT INTO nodes(node_id, lat, lon, alt) VALUES(?, ?, ?, ?)', ('n5', 0, 0, 0))
+        api.DB.commit()
+    from starlette.routing import Match
+
+    def first_match(path: str) -> str:
+        scope = {'type': 'http', 'path': path, 'method': 'DELETE'}
+        for r in api.app.router.routes:
+            if hasattr(r, 'path'):
+                m, _ = r.matches(scope)
+                if m == Match.FULL:
+                    return r.path
+        return ''
+
+    assert first_match('/api/admin/nodes/empty') == '/api/admin/nodes/empty'
+    res = api.api_admin_delete_empty_nodes()
+    data = json.loads(res.body)
+    assert data['deleted'] == 4
+    with api.DB_LOCK:
+        cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n1',))
+        assert cur.fetchone()[0] == 1
+        cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n2',))
+        assert cur.fetchone()[0] == 0
+        cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n3',))
+        assert cur.fetchone()[0] == 0
+        cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n4',))
+        assert cur.fetchone()[0] == 0
+        cur = api.DB.execute('SELECT COUNT(*) FROM nodes WHERE node_id=?', ('n5',))
+        assert cur.fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- allow administrators to prune nodes with no saved data
- add button in admin UI to trigger cleanup
- cover cleanup logic with a unit test
- fix pruning route so static `/empty` path is matched before `{node_id}`
- handle blank metadata fields and bypass caching so empty-node deletions appear immediately
- treat zeroed coordinates as missing data and surface API errors in the admin UI

## Testing
- `apt-get update && apt-get install -y mosquitto`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2d972c883239d3e44fd32144763