### PR TITLE
Add checkbox to toggle zero values in charts

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -84,6 +84,13 @@ const toggles = {
   voltage:     document.getElementById('toggle-voltage'),
   current:     document.getElementById('toggle-current')
 };
+const zeroToggles = {
+  temperature: document.getElementById('zero-temperature'),
+  humidity:    document.getElementById('zero-humidity'),
+  pressure:    document.getElementById('zero-pressure'),
+  voltage:     document.getElementById('zero-voltage'),
+  current:     document.getElementById('zero-current')
+};
 const VIEW_SETTINGS_KEY = 'view_settings';
 let _hasViewSettings = false;
 let _savedNodes = [];
@@ -100,6 +107,7 @@ function saveViewSettings(){
     showNick: $showNick.checked,
     autoref: $autoref.checked,
     toggles: Object.fromEntries(Object.entries(toggles).map(([fam, el]) => [fam, el.checked])),
+    zeroes: Object.fromEntries(Object.entries(zeroToggles).map(([fam, el]) => [fam, el.checked])),
     nodes: Array.from($nodes.querySelectorAll('input[type=checkbox]:checked')).map(cb => cb.value)
   };
   try {
@@ -130,6 +138,11 @@ function loadViewSettings(){
         }
       }
     }
+    if (settings.zeroes){
+      for (const [fam, on] of Object.entries(settings.zeroes)){
+        if (zeroToggles[fam]) zeroToggles[fam].checked = on;
+      }
+    }
     if (Array.isArray(settings.nodes)) _savedNodes = settings.nodes;
   } catch (err) {
     console.error('Failed to load view settings', err);
@@ -142,6 +155,9 @@ for (const fam of Object.keys(charts)){
     cards[fam].style.display = toggles[fam].checked ? '' : 'none';
     saveViewSettings();
   };
+}
+for (const fam of Object.keys(zeroToggles)){
+  zeroToggles[fam].onchange = () => { saveViewSettings(); loadData(); };
 }
 
 async function loadNodes(){
@@ -215,14 +231,16 @@ async function loadData(){
   const showNode = ids.length > 1;
   for (const fam of Object.keys(charts)){
     const unit = units[fam] || '';
+    const showZero = zeroToggles[fam]?.checked;
     const ds = (series[fam] || []).map(s => {
-      const last = s.data.length ? s.data[s.data.length - 1].y.toFixed(2) : 'n/a';
+      const dataPoints = showZero ? s.data : s.data.filter(p => Number(p.y) !== 0);
+      const last = dataPoints.length ? Number(dataPoints[dataPoints.length - 1].y).toFixed(2) : 'n/a';
       const nodeId = s.node_id;
       const short = nodesMap[nodeId]?.short_name || nodeId.slice(-4);
       const node = short;
       const label = showNode ? `${last} ${unit} ${node}` : `${last} ${unit}`;
       const color = colorFor(nodeId);
-      return { label, data: s.data, node, unit, showNode, borderColor: color, backgroundColor: color };
+      return { label, data: dataPoints, node, unit, showNode, borderColor: color, backgroundColor: color };
     });
     charts[fam].data.datasets = ds;
     charts[fam].update();

--- a/static/index.html
+++ b/static/index.html
@@ -129,11 +129,36 @@ small{color:#94a3b8}
     </div>
 
     <div class="grid">
-      <div class="card" id="card-temp"><h3 style="margin:0 0 8px">°C</h3><canvas id="chart-temp"></canvas></div>
-      <div class="card" id="card-hum"><h3 style="margin:0 0 8px">%</h3><canvas id="chart-hum"></canvas></div>
-      <div class="card" id="card-press"><h3 style="margin:0 0 8px">hPa</h3><canvas id="chart-press"></canvas></div>
-      <div class="card" id="card-volt"><h3 style="margin:0 0 8px">V</h3><canvas id="chart-volt"></canvas></div>
-      <div class="card" id="card-curr"><h3 style="margin:0 0 8px">mA</h3><canvas id="chart-curr"></canvas></div>
+      <div class="card" id="card-temp">
+        <h3 style="margin:0 0 8px">°C
+          <label style="font-size:0.8em;margin-left:8px"><input type="checkbox" id="zero-temperature" checked/> Valori 0</label>
+        </h3>
+        <canvas id="chart-temp"></canvas>
+      </div>
+      <div class="card" id="card-hum">
+        <h3 style="margin:0 0 8px">%
+          <label style="font-size:0.8em;margin-left:8px"><input type="checkbox" id="zero-humidity" checked/> Valori 0</label>
+        </h3>
+        <canvas id="chart-hum"></canvas>
+      </div>
+      <div class="card" id="card-press">
+        <h3 style="margin:0 0 8px">hPa
+          <label style="font-size:0.8em;margin-left:8px"><input type="checkbox" id="zero-pressure" checked/> Valori 0</label>
+        </h3>
+        <canvas id="chart-press"></canvas>
+      </div>
+      <div class="card" id="card-volt">
+        <h3 style="margin:0 0 8px">V
+          <label style="font-size:0.8em;margin-left:8px"><input type="checkbox" id="zero-voltage" checked/> Valori 0</label>
+        </h3>
+        <canvas id="chart-volt"></canvas>
+      </div>
+      <div class="card" id="card-curr">
+        <h3 style="margin:0 0 8px">mA
+          <label style="font-size:0.8em;margin-left:8px"><input type="checkbox" id="zero-current" checked/> Valori 0</label>
+        </h3>
+        <canvas id="chart-curr"></canvas>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Allow hiding zero-valued data points per chart with a new checkbox in each card
- Persist zero-value visibility preferences and filter datasets accordingly
- Fix zero-value toggle by coercing y values to numbers before filtering

## Testing
- `pytest` *(fails: test_admin_can_prune_empty_nodes, test_meshtasticator_simulation)*

------
https://chatgpt.com/codex/tasks/task_e_68ba97553d548323b4a3ed0a1217211f