### PR TITLE
Add PyInstaller build setup and Windows instructions

### DIFF
--- a/MeshPlotter.spec
+++ b/MeshPlotter.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['app.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[('config.yml', '.'), ('static', 'static')],
+    hiddenimports=['api'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='MeshPlotter',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ environment.  The file controls:
 6. Visit `http://localhost:8080/traceroutes` for a per‑node traceroute
    summary.
 
+## Installazione su Windows
+
+Per creare un eseguibile autonomo su Windows:
+
+1. Installare le dipendenze di sviluppo: `pip install -r requirements.txt`
+2. Generare il file di specifica:
+   ```bash
+   pyinstaller --name MeshPlotter --add-data config.yml;. --add-data static;static app.py
+   ```
+3. Compilare l'eseguibile "one‑file":
+   ```bash
+   pyinstaller MeshPlotter.spec
+   ```
+4. L'eseguibile `MeshPlotter.exe` verrà creato nella cartella `dist`. Avviarlo
+   con un doppio click o da terminale per avviare il server.
+
+
 ## API overview
 
 | Method | Endpoint               | Description                      |

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,29 @@
+# Configura qui il tuo broker MQTT e i topic da ascoltare
+mqtt:
+  host: "192.168.1.xx"
+  port: 1883
+  username: "user"          # opzionale
+  password: "pass"     # opzionale
+  client_id: "Telemetry"
+  protocol: "v311"            # "v5" oppure "v311"
+  topics: "#"
+
+  # TLS DISABILITATO
+  tls:
+    enabled: false
+    ca_certs: ""
+    certfile: ""
+    keyfile: ""
+    insecure: false
+
+storage:
+  sqlite_path: "./telemetry.db"
+
+web:
+  host: "0.0.0.0"
+  port: 8080
+  default_limit: 2000
+  allow_cors: true
+
+# Decodifica messaggi Protobuf (Meshtastic)
+protobuf_decode: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ paho-mqtt>=1.6
 PyYAML>=6.0
 protobuf>=4.25
 meshtastic
+pyinstaller>=6.0


### PR DESCRIPTION
## Summary
- add PyInstaller to development requirements
- generate MeshPlotter.spec bundling config.yml and static assets
- document Windows one-file build steps

## Testing
- `pyinstaller MeshPlotter.spec`
- `./dist/MeshPlotter --help` *(fails: ModuleNotFoundError: No module named 'api')*
- `pytest -q` *(fails: SyntaxError: unterminated triple-quoted string literal in api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9918499883239e9af4c4307e0eed