### PR TITLE
Deduplicate traceroutes by node pair

### DIFF
--- a/static/traceroutes.html
+++ b/static/traceroutes.html
@@ -33,8 +33,9 @@ section h3{margin:16px 0 8px}
 table{width:100%;border-collapse:collapse;table-layout:fixed}
 th,td{padding:4px 8px;border-bottom:1px solid var(--bd);text-align:left}
 th:first-child,td:first-child{width:40ch}
-th:nth-child(2),td:nth-child(2){text-align:right;width:4ch}
-th:nth-child(3),td:nth-child(3){font-family:monospace;white-space:nowrap}
+th:nth-child(2),td:nth-child(2){width:20ch;white-space:nowrap}
+th:nth-child(3),td:nth-child(3){text-align:right;width:4ch}
+th:nth-child(n+4),td:nth-child(n+4){font-family:monospace;white-space:nowrap}
 </style>
 
 </head>

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -32,7 +32,7 @@ async function loadTraceroutes(){
     const maxHops = Math.max(...list.map(r => r.route.length));
     const thead = document.createElement('thead');
     const headerRow = document.createElement('tr');
-    headerRow.innerHTML = '<th>Destinazione</th><th>Hop</th>';
+    headerRow.innerHTML = '<th>Destinazione</th><th>Data</th><th>Hop</th>';
     for (let i = 1; i <= maxHops; i++){
       const th = document.createElement('th');
       th.textContent = i;
@@ -47,6 +47,11 @@ async function loadTraceroutes(){
       const destCell = document.createElement('td');
       destCell.textContent = `${destName} (${r.dest_id})`;
       tr.appendChild(destCell);
+
+      const timeCell = document.createElement('td');
+      const dt = new Date(r.ts * 1000);
+      timeCell.textContent = dt.toLocaleString();
+      tr.appendChild(timeCell);
 
       const hopCell = document.createElement('td');
       hopCell.textContent = r.hop_count;

--- a/tests/test_api_traceroutes.py
+++ b/tests/test_api_traceroutes.py
@@ -35,3 +35,24 @@ def test_api_traceroutes_deduplication():
     assert entry['hop_count'] == 3
     assert entry['route'] == ['c', 'd']
     reset_traceroutes()
+
+
+def test_api_traceroutes_limit_after_dedup():
+    reset_traceroutes()
+    with api.DB_LOCK:
+        api.DB.executemany(
+            'INSERT INTO traceroutes(ts, src_id, dest_id, route, hop_count) VALUES(?,?,?,?,?)',
+            [
+                (1, 'a', 'c', json.dumps(['x']), 2),
+                (2, 'a', 'b', json.dumps(['y']), 2),
+                (3, 'a', 'b', json.dumps(['z']), 3),
+            ],
+        )
+        api.DB.commit()
+    res = api.api_traceroutes(limit=2)
+    data = json.loads(res.body)
+    assert len(data) == 2
+    assert {r['dest_id'] for r in data} == {'b', 'c'}
+    entry_b = next(r for r in data if r['dest_id'] == 'b')
+    assert entry_b['ts'] == 3
+    reset_traceroutes()

--- a/tests/test_api_traceroutes.py
+++ b/tests/test_api_traceroutes.py
@@ -22,7 +22,7 @@ def test_api_traceroutes_deduplication():
             'INSERT INTO traceroutes(ts, src_id, dest_id, route, hop_count) VALUES(?,?,?,?,?)',
             [
                 (1, 'a', 'b', json.dumps(['c']), 2),
-                (2, 'a', 'b', json.dumps(['c']), 2),
+                (2, 'a', 'b', json.dumps(['c', 'd']), 3),
                 (3, 'a', 'd', json.dumps(['e']), 2),
             ],
         )
@@ -32,4 +32,6 @@ def test_api_traceroutes_deduplication():
     assert len(data) == 2
     entry = next(r for r in data if r['dest_id'] == 'b')
     assert entry['ts'] == 2
+    assert entry['hop_count'] == 3
+    assert entry['route'] == ['c', 'd']
     reset_traceroutes()


### PR DESCRIPTION
## Summary
- ensure /api/traceroutes keeps only the newest route for each src/dest pair
- tighten pruning of empty nodes in admin API
- extend tests to cover hop-count variations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68baba4ecc008323a20b41880d1d1fa6