### PR TITLE
Add optional embedded MQTT broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Copy `example.config.yml` to `config.yml` and adjust the settings to match your
 environment.  The file controls:
 
 - **mqtt** – broker address, credentials, protocol version and the list of
-  topics to subscribe to (string or array).  TLS options are available through
-  the `tls` section.
+  topics to subscribe to (string or array).  Set `embedded_broker: true` to
+  launch a lightweight broker with [amqtt](https://github.com/beerfactory/hbmqtt)
+  inside the application. TLS options are available through the `tls` section.
 - **storage** – path to the SQLite database file.  Use `:memory:` for an
   in‑memory instance.
 - **web** – web server host, port and optional CORS support.
@@ -41,6 +42,8 @@ environment.  The file controls:
 ## Quick start
 
 1. Copy `example.config.yml` to `config.yml` and adjust the broker settings.
+   If you don't have an external MQTT server, set `embedded_broker: true` to
+   run a built-in instance.
 2. Install dependencies: `pip install -r requirements.txt`
 3. Start the server: `python app.py`
 4. Visit `http://localhost:8080` to view the dashboard.

--- a/app.py
+++ b/app.py
@@ -1,14 +1,16 @@
 from api import app
-from config import WEB_HOST, WEB_PORT
+from config import WEB_HOST, WEB_PORT, EMBEDDED_BROKER
 from database import DB, DB_LOCK
 from mqtt_client import start_mqtt
 from processing import process_mqtt_message
 from auto_update import maybe_auto_update
+from mqtt_broker import start_broker
 
 __all__ = [
     "app",
     "process_mqtt_message",
     "start_mqtt",
+    "start_broker",
     "DB",
     "DB_LOCK",
 ]
@@ -17,4 +19,6 @@ if __name__ == "__main__":
     import uvicorn
 
     maybe_auto_update()
+    if EMBEDDED_BROKER:
+        start_broker()
     uvicorn.run(app, host=WEB_HOST, port=WEB_PORT, log_level="info")

--- a/config.py
+++ b/config.py
@@ -38,6 +38,7 @@ MQTT_CLIENT_ID = cfg["mqtt"].get("client_id", "telemetry-plotter")
 MQTT_PROTO = (cfg["mqtt"].get("protocol", "v311") or "v311").lower()
 MQTT_TOPICS = _normalize_topics(cfg["mqtt"].get("topics"))
 TLS_CFG = cfg["mqtt"].get("tls") or {"enabled": False}
+EMBEDDED_BROKER = bool(cfg["mqtt"].get("embedded_broker", False))
 
 # Percorso SQLite relativo al file di config
 _raw_db_path = cfg["storage"].get("sqlite_path")
@@ -59,6 +60,7 @@ print(f"[CFG] MQTT host={MQTT_HOST} port={MQTT_PORT} client_id={MQTT_CLIENT_ID} 
 print(f"[CFG] Topics (raw type={type(cfg['mqtt'].get('topics')).__name__}): {cfg['mqtt'].get('topics')!r}")
 print(f"[CFG] Topics (normalized): {MQTT_TOPICS}")
 print(f"[CFG] SQLite DB: {DB_PATH}")
+print(f"[CFG] Embedded broker: {EMBEDDED_BROKER}")
 
 if not MQTT_HOST or not MQTT_PORT:
     raise SystemExit("[CFG] mqtt.host/port mancanti in config.yml")

--- a/example.config.yml
+++ b/example.config.yml
@@ -7,6 +7,7 @@ mqtt:
   client_id: "Telemetry"
   protocol: "v311"            # "v5" oppure "v311"
   topics: "#"
+  embedded_broker: false      # true per avviare un broker MQTT interno
 
   # TLS DISABILITATO
   tls:

--- a/mqtt_broker.py
+++ b/mqtt_broker.py
@@ -1,0 +1,33 @@
+import asyncio
+import threading
+
+from amqtt.broker import Broker
+
+from config import MQTT_HOST, MQTT_PORT
+
+
+def start_broker() -> Broker:
+    """Avvia un broker MQTT embedded tramite amqtt in un thread dedicato."""
+
+    config = {
+        "listeners": {
+            "default": {
+                "type": "tcp",
+                "bind": f"{MQTT_HOST}:{MQTT_PORT}",
+            }
+        },
+        "sys_interval": 10,
+        "auth": {"allow-anonymous": True},
+    }
+
+    broker = Broker(config)
+
+    async def _start():
+        await broker.start()
+
+    def run():
+        asyncio.run(_start())
+
+    threading.Thread(target=run, daemon=True).start()
+    return broker
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ paho-mqtt>=1.6
 PyYAML>=6.0
 protobuf>=4.25
 meshtastic
+amqtt>=0.11.3


### PR DESCRIPTION
## Summary
- integrate amqtt to offer an optional embedded MQTT broker
- allow enabling the broker via `embedded_broker` in config
- document embedded broker option and update example config

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q` *(fails: SyntaxError in api.py)*


------
https://chatgpt.com/codex/tasks/task_e_68ba97cfba8483239db9523e13ee94b2