### PR TITLE
Deduplicate traceroutes by timestamp and show receive time

### DIFF
--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -50,11 +50,12 @@ async function loadTraceroutes(){
       const destName = nameOf(r.dest_id);
       const destCell = document.createElement('td');
       const dt = new Date(r.ts * 1000);
-      destCell.innerHTML = `${destName} (${r.dest_id})<br><small>${dt.toLocaleString()}</small>`;
+      // show destination ID (user-friendly name and ID) in first cell
+      destCell.innerHTML = `${destName} (${r.dest_id})`;
       tr.appendChild(destCell);
 
       const timeCell = document.createElement('td');
-      const dt = new Date(r.ts * 1000);
+      // show human-readable date/time of reception in second cell
       timeCell.textContent = dt.toLocaleString();
       tr.appendChild(timeCell);
 

--- a/tests/test_api_traceroutes.py
+++ b/tests/test_api_traceroutes.py
@@ -22,9 +22,9 @@ def test_api_traceroutes_deduplication():
         api.DB.executemany(
             'INSERT INTO traceroutes(ts, src_id, dest_id, route, hop_count) VALUES(?,?,?,?,?)',
             [
-                (1, 'a', 'b', json.dumps(['c']), 2),
-                (2, 'a', 'b', json.dumps(['c', 'd']), 3),
-                (3, 'a', 'd', json.dumps(['e']), 2),
+                (100, 'a', 'b', json.dumps(['c', 'd']), 3),
+                (50, 'a', 'b', json.dumps(['c']), 2),
+                (75, 'a', 'd', json.dumps(['e']), 2),
             ],
         )
         api.DB.commit()
@@ -32,7 +32,7 @@ def test_api_traceroutes_deduplication():
     data = json.loads(res.body)
     assert len(data) == 2
     entry = next(r for r in data if r['dest_id'] == 'b')
-    assert entry['ts'] == 2
+    assert entry['ts'] == 100
     assert entry['hop_count'] == 3
     assert entry['route'] == ['c', 'd']
     reset_traceroutes()


### PR DESCRIPTION
## Summary
- Ensure `/api/traceroutes` returns only the newest entry for each source/destination pair, filtering expired routes inside the subquery.
- Show destination ID and reception time in separate columns on the traceroutes page.
- Verify deduplication by timestamp with an updated test.
- Allow pruning empty nodes regardless of altitude.

## Testing
- `pip install -r requirements.txt`
- `apt-get update`
- `apt-get install -y mosquitto`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baed4a6f0c832391add88232efb34a