### PR TITLE
Shorten traceroute hop labels to prevent overlap

### DIFF
--- a/static/traceroutes.html
+++ b/static/traceroutes.html
@@ -35,7 +35,7 @@ th,td{padding:4px 8px;border-bottom:1px solid var(--bd);text-align:left}
 th:first-child,td:first-child{width:40ch}
 th:nth-child(2),td:nth-child(2){width:20ch;white-space:nowrap}
 th:nth-child(3),td:nth-child(3){text-align:right;width:4ch}
-th:nth-child(n+4),td:nth-child(n+4){font-family:monospace;white-space:nowrap}
+th:nth-child(n+4),td:nth-child(n+4){font-family:monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 </style>
 
 </head>

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -5,6 +5,12 @@ function nameOf(id){
   return nodeNames.get(id) || id;
 }
 
+function shortName(id){
+  const name = nameOf(id);
+  // Limit displayed name to keep table cells compact
+  return name.length > 10 ? name.slice(0, 9) + '\u2026' : name;
+}
+
 async function loadNodes(){
   const res = await fetch('/api/nodes');
   const nodes = await res.json();
@@ -66,7 +72,8 @@ async function loadTraceroutes(){
       for (let i = 0; i < maxHops; i++){
         const stepCell = document.createElement('td');
         if (i < r.route.length){
-          stepCell.textContent = nameOf(r.route[i]);
+          stepCell.textContent = shortName(r.route[i]);
+          stepCell.title = nameOf(r.route[i]);
         }
         tr.appendChild(stepCell);
       }


### PR DESCRIPTION
## Summary
- Truncate traceroute hop labels and show full names on hover
- Hide overflow in hop columns so long names don't overlap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be79adf418832397528df57f1b37ab