### PR TITLE
Remove track removal button from map

### DIFF
--- a/static/map.html
+++ b/static/map.html
@@ -73,9 +73,6 @@ header a{color:var(--accent);text-decoration:none}
     <input type="checkbox" id="showNames"/>
     Nomi nodi
   </label>
-
-  <button id="clearRoutes">Elimina tracce</button>
-
 </header>
 <div id="map"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- Remove the "Elimina tracce" button from the map interface

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be7d791fe8832380babd7fe57d6402