### PR TITLE
Use consistent node colors across plots

### DIFF
--- a/static/map.html
+++ b/static/map.html
@@ -44,18 +44,6 @@ header a{color:var(--accent);text-decoration:none}
   text-align:center;
   font-weight:600;
 }
-.hop-legend{
-  background:var(--card-bg);
-  padding:4px;
-  line-height:14px;
-  color:var(--text);
-}
-.hop-legend span{
-  display:inline-block;
-  width:12px;
-  height:12px;
-  margin-right:4px;
-}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- assign each node a deterministic color and reuse it for all plots
- color traceroute markers per node and remove hop-based legend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be80157088832382cf15b09842c60a