### PR TITLE
Fix clear traceroutes button

### DIFF
--- a/static/traceroutes.html
+++ b/static/traceroutes.html
@@ -45,7 +45,7 @@ th:nth-child(n+4),td:nth-child(n+4){font-family:monospace;white-space:nowrap;ove
   <a href="/" style="margin-left:auto">Telemetria</a>
   <a href="/map">Mappa</a>
   <a href="/setup">Setup</a>
-  <button id="clearRoutes">Elimina tracce</button>
+  <button id="clearRoutes" type="button">Elimina tracce</button>
 </header>
 <div id="routes"></div>
 <script src="/static/traceroutes.js"></script>

--- a/static/traceroutes.js
+++ b/static/traceroutes.js
@@ -86,7 +86,8 @@ async function loadTraceroutes(){
   }
 }
 
-async function clearAllRoutes(){
+async function clearAllRoutes(ev){
+  ev?.preventDefault();
   if (!confirm('Eliminare tutte le tracce?')) return;
   let res;
   try{


### PR DESCRIPTION
## Summary
- ensure traceroute deletion button uses type="button" to avoid unwanted form submission
- prevent default click behavior and refresh list after deletion

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be9732d2648323a0b0d6d741820ee9