### PR TITLE
Treat zero timestamps as missing in position updates

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -195,6 +195,8 @@ def _extract_position(
                             ts_val = int(obj[key])
                             if "ms" in key.lower():
                                 ts_val = int(float(obj[key]) / 1000)
+                            if ts_val == 0:
+                                ts_val = None
                         except (TypeError, ValueError):
                             ts_val = None
                         break


### PR DESCRIPTION
## Summary
- Treat timestamp 0 as missing in `_extract_position` so arrival time is used
- Test that a position with `time: 0` updates coordinates using arrival time

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c15a208a188323bdb662e35c0ec061